### PR TITLE
Add opacity controls for map layers

### DIFF
--- a/app/MapComponent.jsx
+++ b/app/MapComponent.jsx
@@ -21,6 +21,8 @@ export default function MapComponent({
   onMapInitialized,
   showTitleLayer,
   showRequestLayer,
+  titleOpacity,
+  requestOpacity,
 }) {
   const mapRef = useRef(null)
   const geoJsonLayerRef = useRef(null)
@@ -652,11 +654,13 @@ export default function MapComponent({
             },
           }).addTo(mapRef.current)
 
-          // Mostramos etiquetas solo entre zoom 15 y 19
-          const currentZoom = mapRef.current.getZoom()
-          if (currentZoom >= 15 && currentZoom <= 19 && labelsLayerRef.current) {
-            mapRef.current.addLayer(labelsLayerRef.current)
-          }
+        // Mostramos etiquetas solo entre zoom 15 y 19
+        const currentZoom = mapRef.current.getZoom()
+        if (currentZoom >= 15 && currentZoom <= 19 && labelsLayerRef.current) {
+          mapRef.current.addLayer(labelsLayerRef.current)
+        }
+        } else {
+          layerRef.current.setStyle(layerStyle)
         }
       } else if (layerRef.current) {
         // Si ya no se va a mostrar, removemos todo
@@ -676,14 +680,14 @@ export default function MapComponent({
         color: "#894444",
         weight: 2,
         fillColor: "#A46F48",
-        fillOpacity: 0.6,
+        fillOpacity: titleOpacity,
       })
 
       updateLayer(showRequestLayer, requestLayerRef, requestLabelsLayerRef, "Solicitud Vigente", {
         color: "#F0C567",
         weight: 2,
         fillColor: "#FFF0AF",
-        fillOpacity: 0.7,
+        fillOpacity: requestOpacity,
       })
 
       // Forzamos que Leaflet refresque la vista
@@ -692,7 +696,7 @@ export default function MapComponent({
       console.error("Error al actualizar las capas:", error)
       setError("Error al actualizar las capas del mapa")
     }
-  }, [showTitleLayer, showRequestLayer, findLayerNumbers])
+  }, [showTitleLayer, showRequestLayer, titleOpacity, requestOpacity, findLayerNumbers])
 
   // Alternar entre capa base OSM y Satélite
   const toggleBaseLayer = useCallback(() => {

--- a/app/components.jsx
+++ b/app/components.jsx
@@ -42,6 +42,8 @@ export default function Component() {
   const inputRef = useRef(null)
   const [showTitleLayer, setShowTitleLayer] = useState(false)
   const [showRequestLayer, setShowRequestLayer] = useState(false)
+  const [titleOpacity, setTitleOpacity] = useState(0.6)
+  const [requestOpacity, setRequestOpacity] = useState(0.7)
 
   const handleApply = useCallback(() => {
     if (!expedientCode) {
@@ -245,18 +247,40 @@ export default function Component() {
           <Button onClick={handleApply} className="w-full bg-blue-500 hover:bg-blue-600 text-white">
             Aplicar
           </Button>
-          <div className="space-y-2">
-            <div className="flex items-center justify-between">
-              <Label htmlFor="titleLayer" className="text-sm">
-                Títulos Vigentes
-              </Label>
-              <Switch id="titleLayer" checked={showTitleLayer} onCheckedChange={setShowTitleLayer} />
+          <div className="space-y-4">
+            <div>
+              <div className="flex items-center justify-between">
+                <Label htmlFor="titleLayer" className="text-sm">
+                  Títulos Vigentes
+                </Label>
+                <Switch id="titleLayer" checked={showTitleLayer} onCheckedChange={setShowTitleLayer} />
+              </div>
+              <input
+                type="range"
+                min="0"
+                max="1"
+                step="0.1"
+                value={titleOpacity}
+                onChange={(e) => setTitleOpacity(parseFloat(e.target.value))}
+                className="w-full mt-1"
+              />
             </div>
-            <div className="flex items-center justify-between">
-              <Label htmlFor="requestLayer" className="text-sm">
-                Solicitudes Vigente
-              </Label>
-              <Switch id="requestLayer" checked={showRequestLayer} onCheckedChange={setShowRequestLayer} />
+            <div>
+              <div className="flex items-center justify-between">
+                <Label htmlFor="requestLayer" className="text-sm">
+                  Solicitudes Vigente
+                </Label>
+                <Switch id="requestLayer" checked={showRequestLayer} onCheckedChange={setShowRequestLayer} />
+              </div>
+              <input
+                type="range"
+                min="0"
+                max="1"
+                step="0.1"
+                value={requestOpacity}
+                onChange={(e) => setRequestOpacity(parseFloat(e.target.value))}
+                className="w-full mt-1"
+              />
             </div>
           </div>
 
@@ -297,6 +321,8 @@ export default function Component() {
           onMapInitialized={handleMapInitialized}
           showTitleLayer={showTitleLayer}
           showRequestLayer={showRequestLayer}
+          titleOpacity={titleOpacity}
+          requestOpacity={requestOpacity}
         />
         {!showSidebar && (
           <Button


### PR DESCRIPTION
## Summary
- add titleOpacity and requestOpacity controls in sidebar
- connect opacity sliders to `MapComponent`
- allow updating feature layer styles based on current opacity

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe2028b54832e9cb63893df3a0431