### PR TITLE
Fix Google tile layer over HTTPS

### DIFF
--- a/app/MapComponent.jsx
+++ b/app/MapComponent.jsx
@@ -88,7 +88,7 @@ export default function MapComponent({
       })
 
       // Capa satelital
-      const satelliteLayer = L.tileLayer("http://{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}", {
+      const satelliteLayer = L.tileLayer("https://{s}.google.com/vt/lyrs=s&x={x}&y={y}&z={z}", {
         maxZoom: 20,
         subdomains: ["mt0", "mt1", "mt2", "mt3"],
         attribution: "© Google",
@@ -706,7 +706,7 @@ export default function MapComponent({
     })
 
     if (baseLayer === "osm") {
-      L.tileLayer("http://{s}.google.com/vt/lyrs=s,h&x={x}&y={y}&z={z}", {
+      L.tileLayer("https://{s}.google.com/vt/lyrs=s,h&x={x}&y={y}&z={z}", {
         maxZoom: 22,
         subdomains: ["mt0", "mt1", "mt2", "mt3"],
         attribution: "© Google",


### PR DESCRIPTION
## Summary
- switch to HTTPS for Google tile layers to avoid mixed content issues

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe01eaa6c832ea5e3bf228c798223