### PR TITLE
Update layer opacity UI

### DIFF
--- a/app/MapComponent.jsx
+++ b/app/MapComponent.jsx
@@ -19,8 +19,8 @@ export default function MapComponent({
   onCoordinatesUpdate,
   searchTrigger,
   onMapInitialized,
-  showTitleLayer,
-  showRequestLayer,
+  titleOpacity,
+  requestOpacity,
 }) {
   const mapRef = useRef(null)
   const geoJsonLayerRef = useRef(null)
@@ -39,6 +39,9 @@ export default function MapComponent({
   const [drawingColor, setDrawingColor] = useState("#f357a1")
   const [mapInstance, setMapInstance] = useState(null)
   const [showColorPicker, setShowColorPicker] = useState(false)
+
+  const showTitleLayer = titleOpacity > 0
+  const showRequestLayer = requestOpacity > 0
 
   // Función para formatear fechas
   const formatDate = (value) => {
@@ -652,11 +655,13 @@ export default function MapComponent({
             },
           }).addTo(mapRef.current)
 
-          // Mostramos etiquetas solo entre zoom 15 y 19
-          const currentZoom = mapRef.current.getZoom()
-          if (currentZoom >= 15 && currentZoom <= 19 && labelsLayerRef.current) {
-            mapRef.current.addLayer(labelsLayerRef.current)
-          }
+        // Mostramos etiquetas solo entre zoom 15 y 19
+        const currentZoom = mapRef.current.getZoom()
+        if (currentZoom >= 15 && currentZoom <= 19 && labelsLayerRef.current) {
+          mapRef.current.addLayer(labelsLayerRef.current)
+        }
+        } else {
+          layerRef.current.setStyle(layerStyle)
         }
       } else if (layerRef.current) {
         // Si ya no se va a mostrar, removemos todo
@@ -676,14 +681,14 @@ export default function MapComponent({
         color: "#894444",
         weight: 2,
         fillColor: "#A46F48",
-        fillOpacity: 0.6,
+        fillOpacity: titleOpacity,
       })
 
       updateLayer(showRequestLayer, requestLayerRef, requestLabelsLayerRef, "Solicitud Vigente", {
         color: "#F0C567",
         weight: 2,
         fillColor: "#FFF0AF",
-        fillOpacity: 0.7,
+        fillOpacity: requestOpacity,
       })
 
       // Forzamos que Leaflet refresque la vista
@@ -692,7 +697,7 @@ export default function MapComponent({
       console.error("Error al actualizar las capas:", error)
       setError("Error al actualizar las capas del mapa")
     }
-  }, [showTitleLayer, showRequestLayer, findLayerNumbers])
+  }, [titleOpacity, requestOpacity, findLayerNumbers])
 
   // Alternar entre capa base OSM y Satélite
   const toggleBaseLayer = useCallback(() => {

--- a/app/components.jsx
+++ b/app/components.jsx
@@ -4,7 +4,6 @@ import { useState, useEffect, useCallback, useRef } from "react"
 import dynamic from "next/dynamic"
 import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
-import { Switch } from "@/components/ui/switch"
 import { Button } from "@/components/ui/button"
 import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table"
 import { Loader2, ChevronLeft, Search, Download, RefreshCw, ChevronRight } from "lucide-react"
@@ -40,8 +39,8 @@ export default function Component() {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState(null)
   const inputRef = useRef(null)
-  const [showTitleLayer, setShowTitleLayer] = useState(false)
-  const [showRequestLayer, setShowRequestLayer] = useState(false)
+  const [titleOpacity, setTitleOpacity] = useState(0.6)
+  const [requestOpacity, setRequestOpacity] = useState(0.7)
 
   const handleApply = useCallback(() => {
     if (!expedientCode) {
@@ -245,18 +244,36 @@ export default function Component() {
           <Button onClick={handleApply} className="w-full bg-blue-500 hover:bg-blue-600 text-white">
             Aplicar
           </Button>
-          <div className="space-y-2">
-            <div className="flex items-center justify-between">
+          <div className="space-y-4">
+            <div className="flex items-center justify-between gap-4">
               <Label htmlFor="titleLayer" className="text-sm">
                 Títulos Vigentes
               </Label>
-              <Switch id="titleLayer" checked={showTitleLayer} onCheckedChange={setShowTitleLayer} />
+              <input
+                id="titleLayer"
+                type="range"
+                min="0"
+                max="1"
+                step="0.1"
+                value={titleOpacity}
+                onChange={(e) => setTitleOpacity(parseFloat(e.target.value))}
+                className="w-32"
+              />
             </div>
-            <div className="flex items-center justify-between">
+            <div className="flex items-center justify-between gap-4">
               <Label htmlFor="requestLayer" className="text-sm">
-                Solicitudes Vigente
+                Solicitudes Vigentes
               </Label>
-              <Switch id="requestLayer" checked={showRequestLayer} onCheckedChange={setShowRequestLayer} />
+              <input
+                id="requestLayer"
+                type="range"
+                min="0"
+                max="1"
+                step="0.1"
+                value={requestOpacity}
+                onChange={(e) => setRequestOpacity(parseFloat(e.target.value))}
+                className="w-32"
+              />
             </div>
           </div>
 
@@ -295,8 +312,8 @@ export default function Component() {
           onCoordinatesUpdate={handleCoordinatesUpdate}
           searchTrigger={searchTrigger}
           onMapInitialized={handleMapInitialized}
-          showTitleLayer={showTitleLayer}
-          showRequestLayer={showRequestLayer}
+          titleOpacity={titleOpacity}
+          requestOpacity={requestOpacity}
         />
         {!showSidebar && (
           <Button

--- a/app/components.jsx
+++ b/app/components.jsx
@@ -244,8 +244,8 @@ export default function Component() {
           <Button onClick={handleApply} className="w-full bg-blue-500 hover:bg-blue-600 text-white">
             Aplicar
           </Button>
-          <div className="space-y-4">
-            <div className="flex items-center justify-between gap-4">
+          <div className="space-y-2">
+            <div className="flex items-center justify-between gap-2">
               <Label htmlFor="titleLayer" className="text-sm">
                 Títulos Vigentes
               </Label>
@@ -260,7 +260,7 @@ export default function Component() {
                 className="w-32"
               />
             </div>
-            <div className="flex items-center justify-between gap-4">
+            <div className="flex items-center justify-between gap-2">
               <Label htmlFor="requestLayer" className="text-sm">
                 Solicitudes Vigentes
               </Label>


### PR DESCRIPTION
## Summary
- remove layer toggle switches
- keep opacity sliders inline with labels
- compute which layers are visible based on slider values

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe2028b54832e9cb63893df3a0431