### PR TITLE
Fix opacity persistence on zoom

### DIFF
--- a/app/MapComponent.jsx
+++ b/app/MapComponent.jsx
@@ -42,11 +42,21 @@ export default function MapComponent({
   const [mapInstance, setMapInstance] = useState(null)
   const [showColorPicker, setShowColorPicker] = useState(false)
   const layerNumbersCacheRef = useRef(null)
+  const titleOpacityRef = useRef(titleOpacity)
+  const requestOpacityRef = useRef(requestOpacity)
 
   // Determinar si las capas deben mostrarse teniendo en cuenta el valor
   // proveniente de los controles y la opacidad configurada
   const shouldShowTitleLayer = showTitleLayer && titleOpacity > 0
   const shouldShowRequestLayer = showRequestLayer && requestOpacity > 0
+
+  useEffect(() => {
+    titleOpacityRef.current = titleOpacity
+  }, [titleOpacity])
+
+  useEffect(() => {
+    requestOpacityRef.current = requestOpacity
+  }, [requestOpacity])
 
   // Función para formatear fechas
   const formatDate = (value) => {
@@ -703,6 +713,7 @@ export default function MapComponent({
           mapRef.current.addLayer(labelsLayerRef.current)
         }
         } else {
+          layerRef.current.options.style = layerStyle
           layerRef.current.setStyle(layerStyle)
         }
       } else if (layerRef.current) {
@@ -759,9 +770,40 @@ export default function MapComponent({
     shouldShowTitleLayer,
     shouldShowRequestLayer,
     titleOpacity,
-    requestOpacity,
-    findLayerNumbers,
+  requestOpacity,
+  findLayerNumbers,
   ])
+
+  // Reaplicar opacidad según el valor de los sliders al hacer zoom
+  useEffect(() => {
+    if (!mapRef.current) return
+
+    const map = mapRef.current
+
+    const handleZoom = () => {
+      if (titleLayerRef.current) {
+        const style = {
+          ...titleLayerRef.current.options.style,
+          fillOpacity: titleOpacityRef.current,
+        }
+        titleLayerRef.current.options.style = style
+        titleLayerRef.current.setStyle(style)
+      }
+      if (requestLayerRef.current) {
+        const style = {
+          ...requestLayerRef.current.options.style,
+          fillOpacity: requestOpacityRef.current,
+        }
+        requestLayerRef.current.options.style = style
+        requestLayerRef.current.setStyle(style)
+      }
+    }
+
+    map.on("zoomend", handleZoom)
+    return () => {
+      map.off("zoomend", handleZoom)
+    }
+  }, [mapInstance])
 
 
 

--- a/app/components.jsx
+++ b/app/components.jsx
@@ -255,44 +255,35 @@ export default function Component() {
             Aplicar
           </Button>
           <div className="space-y-4">
-            <div>
-              <div className="flex items-center justify-between">
-                <Label htmlFor="titleLayer" className="text-sm">
-                  Títulos Vigentes
-                </Label>
-                <Switch id="titleLayer" checked={showTitleLayer} onCheckedChange={setShowTitleLayer} />
-              </div>
+            <div className="flex items-center gap-2">
+              <Label htmlFor="titleLayer" className="text-sm">
+                Títulos Vigentes
+              </Label>
               <input
-              
                 type="range"
                 min="0"
                 max="1"
                 step="0.1"
                 value={titleOpacity}
                 onChange={(e) => setTitleOpacity(parseFloat(e.target.value))}
-
-                className="w-full mt-1"
+                className="w-32"
               />
+              <Switch id="titleLayer" checked={showTitleLayer} onCheckedChange={setShowTitleLayer} />
             </div>
-            <div>
-              <div className="flex items-center justify-between">
-                <Label htmlFor="requestLayer" className="text-sm">
-                  Solicitudes Vigente
-                </Label>
-                <Switch id="requestLayer" checked={showRequestLayer} onCheckedChange={setShowRequestLayer} />
-              </div>
+            <div className="flex items-center gap-2">
+              <Label htmlFor="requestLayer" className="text-sm">
+                Solicitudes Vigente
+              </Label>
               <input
-
                 type="range"
                 min="0"
                 max="1"
                 step="0.1"
                 value={requestOpacity}
                 onChange={(e) => setRequestOpacity(parseFloat(e.target.value))}
-
-                className="w-full mt-1"
-
+                className="w-32"
               />
+              <Switch id="requestLayer" checked={showRequestLayer} onCheckedChange={setShowRequestLayer} />
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- keep slider widths consistent and shorter
- store latest opacity values via refs
- reapply opacity from refs whenever the map zooms

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408b4deae0832e8ed7134a31f74842