### PR TITLE
Fix slider width mismatch

### DIFF
--- a/app/components.jsx
+++ b/app/components.jsx
@@ -275,15 +275,15 @@ export default function Component() {
               <Label htmlFor="requestLayer" className="text-sm">
                 Solicitudes Vigente
               </Label>
-              <input
-                type="range"
-                min="0"
-                max="1"
-                step="0.1"
-                value={requestOpacity}
-                onChange={(e) => setRequestOpacity(parseFloat(e.target.value))}
-                className="w-32"
-              />
+                <input
+                  type="range"
+                  min="0"
+                  max="1"
+                  step="0.1"
+                  value={requestOpacity}
+                  onChange={(e) => setRequestOpacity(parseFloat(e.target.value))}
+                  className="flex-1"
+                />
               <Switch id="requestLayer" checked={showRequestLayer} onCheckedChange={setShowRequestLayer} />
             </div>
           </div>


### PR DESCRIPTION
## Summary
- make both opacity sliders use `flex-1` so they have equal width

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840da22b9b8832eab6019535a3e7689