### PR TITLE
Agregar capa Servicios ANM (MapServer/3) debajo de Solicitudes Vigente

### DIFF
--- a/app/MapComponent.jsx
+++ b/app/MapComponent.jsx
@@ -21,9 +21,11 @@ export default function MapComponent({
   onMapInitialized,
   showTitleLayer,
   showRequestLayer,
+  showAnmServiceLayer,
   showHistoricalTitleLayer,
   titleOpacity,
   requestOpacity,
+  anmServiceOpacity,
   historicalTitleOpacity,
 }) {
   const mapRef = useRef(null)
@@ -31,14 +33,17 @@ export default function MapComponent({
   const verticesLayerRef = useRef(null)
   const titleLayerRef = useRef(null)
   const requestLayerRef = useRef(null)
+  const anmServiceLayerRef = useRef(null)
   const historicalTitleLayerRef = useRef(null)
   const titleOpacityRef = useRef(titleOpacity)
   const requestOpacityRef = useRef(requestOpacity)
+  const anmServiceOpacityRef = useRef(anmServiceOpacity)
   const historicalTitleOpacityRef = useRef(historicalTitleOpacity)
   const lastSearchTriggerRef = useRef(0)
   const labelsLayerRef = useRef(null)
   const titleLabelsLayerRef = useRef(null)
   const requestLabelsLayerRef = useRef(null)
+  const anmServiceLabelsLayerRef = useRef(null)
   const historicalTitleLabelsLayerRef = useRef(null)
   const drawControlRef = useRef(null)
   const drawnItemsRef = useRef(null)
@@ -81,6 +86,10 @@ export default function MapComponent({
   }, [requestOpacity])
 
   useEffect(() => {
+    anmServiceOpacityRef.current = anmServiceOpacity
+  }, [anmServiceOpacity])
+
+  useEffect(() => {
     historicalTitleOpacityRef.current = historicalTitleOpacity
   }, [historicalTitleOpacity])
 
@@ -88,6 +97,7 @@ export default function MapComponent({
   // proveniente de los controles y la opacidad configurada
   const shouldShowTitleLayer = showTitleLayer && titleOpacity > 0
   const shouldShowRequestLayer = showRequestLayer && requestOpacity > 0
+  const shouldShowAnmServiceLayer = showAnmServiceLayer && anmServiceOpacity > 0
   const shouldShowHistoricalTitleLayer = showHistoricalTitleLayer && historicalTitleOpacity > 0
 
   // Función para formatear fechas
@@ -900,6 +910,20 @@ export default function MapComponent({
       )
 
       updateLayer(
+        shouldShowAnmServiceLayer,
+        anmServiceLayerRef,
+        anmServiceLabelsLayerRef,
+        null,
+        {
+          color: "#00A8E8",
+          weight: 2,
+          fillColor: "#90E0EF",
+          fillOpacity: anmServiceOpacity,
+        },
+        "https://geo.anm.gov.co/webgis/rest/services/ANM/ServiciosANM/MapServer/3",
+      )
+
+      updateLayer(
         shouldShowRequestLayer,
         requestLayerRef,
         requestLabelsLayerRef,
@@ -938,9 +962,11 @@ export default function MapComponent({
     mapInstance,
     shouldShowTitleLayer,
     shouldShowRequestLayer,
+    shouldShowAnmServiceLayer,
     shouldShowHistoricalTitleLayer,
     titleOpacity,
     requestOpacity,
+    anmServiceOpacity,
     historicalTitleOpacity,
     findLayerNumbers,
   ])
@@ -975,6 +1001,14 @@ export default function MapComponent({
         }
         historicalTitleLayerRef.current.options.style = style
         historicalTitleLayerRef.current.setStyle(style)
+      }
+      if (anmServiceLayerRef.current) {
+        const style = {
+          ...anmServiceLayerRef.current.options.style,
+          fillOpacity: anmServiceOpacityRef.current,
+        }
+        anmServiceLayerRef.current.options.style = style
+        anmServiceLayerRef.current.setStyle(style)
       }
     }
 

--- a/app/components.jsx
+++ b/app/components.jsx
@@ -49,9 +49,11 @@ export default function Component() {
   const inputRef = useRef(null)
   const [showTitleLayer, setShowTitleLayer] = useState(false)
   const [showRequestLayer, setShowRequestLayer] = useState(false)
+  const [showAnmServiceLayer, setShowAnmServiceLayer] = useState(false)
   const [showHistoricalTitleLayer, setShowHistoricalTitleLayer] = useState(false)
   const [titleOpacity, setTitleOpacity] = useState(0.6)
   const [requestOpacity, setRequestOpacity] = useState(0.7)
+  const [anmServiceOpacity, setAnmServiceOpacity] = useState(0.7)
   const [historicalTitleOpacity, setHistoricalTitleOpacity] = useState(0.5)
 
   const handleApply = useCallback(() => {
@@ -290,6 +292,21 @@ export default function Component() {
               <Switch id="requestLayer" checked={showRequestLayer} onCheckedChange={setShowRequestLayer} />
             </div>
             <div className="flex items-center gap-2">
+              <Label htmlFor="anmServiceLayer" className="text-sm">
+                Capa ANM Servicio 3
+              </Label>
+              <input
+                type="range"
+                min="0"
+                max="1"
+                step="0.1"
+                value={anmServiceOpacity}
+                onChange={(e) => setAnmServiceOpacity(parseFloat(e.target.value))}
+                className="flex-1"
+              />
+              <Switch id="anmServiceLayer" checked={showAnmServiceLayer} onCheckedChange={setShowAnmServiceLayer} />
+            </div>
+            <div className="flex items-center gap-2">
               <Label htmlFor="historicalTitleLayer" className="text-sm">
                 Título Histórico
               </Label>
@@ -347,9 +364,11 @@ export default function Component() {
           onMapInitialized={handleMapInitialized}
           showTitleLayer={showTitleLayer}
           showRequestLayer={showRequestLayer}
+          showAnmServiceLayer={showAnmServiceLayer}
           showHistoricalTitleLayer={showHistoricalTitleLayer}
           titleOpacity={titleOpacity}
           requestOpacity={requestOpacity}
+          anmServiceOpacity={anmServiceOpacity}
           historicalTitleOpacity={historicalTitleOpacity}
         />
         {!showSidebar && (


### PR DESCRIPTION
### Motivation
- Añadir la capa del servicio ANM `MapServer/3` y exponerla en el panel de capas para que quede visualmente debajo de la capa “Solicitudes Vigente”.

### Description
- Añadido estado y controles en `app/components.jsx`: `showAnmServiceLayer` y `anmServiceOpacity`, más un slider y `Switch` ubicados debajo de “Solicitudes Vigente”.
- Pasada la nueva prop `showAnmServiceLayer` y `anmServiceOpacity` a `MapComponent` y propagados los cambios en las llamadas de renderizado de capas.
- En `app/MapComponent.jsx` se añadieron `refs` y `opacityRef` para la capa ANM, se integró un `updateLayer` específico apuntando a `https://geo.anm.gov.co/webgis/rest/services/ANM/ServiciosANM/MapServer/3`, y se colocó su llamada antes de la de “Solicitud Vigente” para quedar por debajo visualmente.
- Se añadió re-aplicación de opacidad para la capa ANM en el manejador de zoom para que la opacidad del slider se mantenga durante cambios de zoom.

### Testing
- Ejecutado `npm run lint` y falló porque no existe el script `lint` en este proyecto (no se pudo verificar linting).
- Ejecutado `npm test -- --watch=false` y Jest se ejecutó pero no hay tests definidos, por lo que sale con código de error (sin pruebas automáticas que ejecutar).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0265a51038832eb2b6a71899b0e083)