### PR TITLE
Add ANM 'ServiciosANM' layer, make search resilient and surface errors with dismissible banner

### DIFF
--- a/app/MapComponent.jsx
+++ b/app/MapComponent.jsx
@@ -21,9 +21,11 @@ export default function MapComponent({
   onMapInitialized,
   showTitleLayer,
   showRequestLayer,
+  showAnmServiceLayer,
   showHistoricalTitleLayer,
   titleOpacity,
   requestOpacity,
+  anmServiceOpacity,
   historicalTitleOpacity,
 }) {
   const mapRef = useRef(null)
@@ -31,14 +33,17 @@ export default function MapComponent({
   const verticesLayerRef = useRef(null)
   const titleLayerRef = useRef(null)
   const requestLayerRef = useRef(null)
+  const anmServiceLayerRef = useRef(null)
   const historicalTitleLayerRef = useRef(null)
   const titleOpacityRef = useRef(titleOpacity)
   const requestOpacityRef = useRef(requestOpacity)
+  const anmServiceOpacityRef = useRef(anmServiceOpacity)
   const historicalTitleOpacityRef = useRef(historicalTitleOpacity)
   const lastSearchTriggerRef = useRef(0)
   const labelsLayerRef = useRef(null)
   const titleLabelsLayerRef = useRef(null)
   const requestLabelsLayerRef = useRef(null)
+  const anmServiceLabelsLayerRef = useRef(null)
   const historicalTitleLabelsLayerRef = useRef(null)
   const drawControlRef = useRef(null)
   const drawnItemsRef = useRef(null)
@@ -49,6 +54,7 @@ export default function MapComponent({
   const [drawingColor, setDrawingColor] = useState("#f357a1")
   const [mapInstance, setMapInstance] = useState(null)
   const [showColorPicker, setShowColorPicker] = useState(false)
+  const [showErrorBanner, setShowErrorBanner] = useState(false)
   const [isCompassActive, setIsCompassActive] = useState(false)
   const [deviceHeading, setDeviceHeading] = useState(null)
   const layerNumbersCacheRef = useRef(null)
@@ -81,6 +87,10 @@ export default function MapComponent({
   }, [requestOpacity])
 
   useEffect(() => {
+    anmServiceOpacityRef.current = anmServiceOpacity
+  }, [anmServiceOpacity])
+
+  useEffect(() => {
     historicalTitleOpacityRef.current = historicalTitleOpacity
   }, [historicalTitleOpacity])
 
@@ -88,6 +98,7 @@ export default function MapComponent({
   // proveniente de los controles y la opacidad configurada
   const shouldShowTitleLayer = showTitleLayer && titleOpacity > 0
   const shouldShowRequestLayer = showRequestLayer && requestOpacity > 0
+  const shouldShowAnmServiceLayer = showAnmServiceLayer && anmServiceOpacity > 0
   const shouldShowHistoricalTitleLayer = showHistoricalTitleLayer && historicalTitleOpacity > 0
 
   // Función para formatear fechas
@@ -673,6 +684,7 @@ export default function MapComponent({
   // Función para cargar datos de un expediente específico
   const fetchData = useCallback(async () => {
     if (!mapRef.current || !expedientCode) return
+    const normalizedCode = expedientCode.trim().toUpperCase().replace(/'/g, "''")
 
     const layerNumbers = await findLayerNumbers()
 
@@ -687,11 +699,29 @@ export default function MapComponent({
         },
       },
       {
+        url: "https://geo.anm.gov.co/webgis/rest/services/ANM/ServiciosANM/MapServer/3/query",
+        style: {
+          color: "#6E4B3A",
+          weight: 3,
+          fillColor: "#B68863",
+          fillOpacity: 0.6,
+        },
+      },
+      {
         url: `https://annamineria.anm.gov.co/annageo/rest/services/SIGM/TenureLayers/MapServer/${layerNumbers["Solicitud Vigente"]}/query`,
         style: {
           color: "#F0C567",
           weight: 3,
           fillColor: "#FFF0AF",
+          fillOpacity: 0.6,
+        },
+      },
+      {
+        url: "https://annamineria.anm.gov.co/annageo/rest/services/SIGM/VisorInterno/MapServer/87/query",
+        style: {
+          color: "#22577A",
+          weight: 3,
+          fillColor: "#38A3A5",
           fillOpacity: 0.6,
         },
       },
@@ -714,7 +744,7 @@ export default function MapComponent({
     // Buscamos en ambas capas (Título y Solicitud)
     for (const layer of layers) {
       const params = new URLSearchParams({
-        where: `TENURE_ID='${expedientCode}'`,
+        where: `(UPPER(TENURE_ID)='${normalizedCode}' OR UPPER(CODIGO_EXPEDIENTE)='${normalizedCode}')`,
         outFields: "*",
         returnGeometry: "true",
         f: "geojson",
@@ -797,11 +827,13 @@ export default function MapComponent({
         }
       } catch (error) {
         console.error("Error al obtener los datos:", error)
+        setShowErrorBanner(true)
         setError("Error al obtener los datos del expediente")
       }
     }
 
     // Si llegamos aquí, no se encontró el expediente
+    setShowErrorBanner(true)
     setError(`No se encontró un polígono con el expediente introducido '${expedientCode}'.`)
     onCoordinatesUpdate([], null)
   }, [expedientCode, onCoordinatesUpdate, findLayerNumbers])
@@ -811,6 +843,7 @@ export default function MapComponent({
     if (searchTrigger !== lastSearchTriggerRef.current) {
       lastSearchTriggerRef.current = searchTrigger
       setError(null)
+      setShowErrorBanner(false)
       fetchData()
     }
   }, [searchTrigger, fetchData])
@@ -900,6 +933,20 @@ export default function MapComponent({
       )
 
       updateLayer(
+        shouldShowAnmServiceLayer,
+        anmServiceLayerRef,
+        anmServiceLabelsLayerRef,
+        null,
+        {
+          color: "#6E4B3A",
+          weight: 2,
+          fillColor: "#B68863",
+          fillOpacity: anmServiceOpacity,
+        },
+        "https://geo.anm.gov.co/webgis/rest/services/ANM/ServiciosANM/MapServer/3",
+      )
+
+      updateLayer(
         shouldShowRequestLayer,
         requestLayerRef,
         requestLabelsLayerRef,
@@ -931,6 +978,7 @@ export default function MapComponent({
       mapRef.current.invalidateSize()
     } catch (error) {
       console.error("Error al actualizar las capas:", error)
+      setShowErrorBanner(true)
       setError("Error al actualizar las capas del mapa")
     }
 
@@ -938,9 +986,11 @@ export default function MapComponent({
     mapInstance,
     shouldShowTitleLayer,
     shouldShowRequestLayer,
+    shouldShowAnmServiceLayer,
     shouldShowHistoricalTitleLayer,
     titleOpacity,
     requestOpacity,
+    anmServiceOpacity,
     historicalTitleOpacity,
     findLayerNumbers,
   ])
@@ -975,6 +1025,14 @@ export default function MapComponent({
         }
         historicalTitleLayerRef.current.options.style = style
         historicalTitleLayerRef.current.setStyle(style)
+      }
+      if (anmServiceLayerRef.current) {
+        const style = {
+          ...anmServiceLayerRef.current.options.style,
+          fillOpacity: anmServiceOpacityRef.current,
+        }
+        anmServiceLayerRef.current.options.style = style
+        anmServiceLayerRef.current.setStyle(style)
       }
     }
 
@@ -1113,6 +1171,7 @@ export default function MapComponent({
     }
 
     setError(null)
+    setShowErrorBanner(false)
     const started = await startDeviceOrientationTracking()
     if (started) {
       setIsCompassActive(true)
@@ -1123,11 +1182,13 @@ export default function MapComponent({
     if (!mapRef.current) return
 
     if (!navigator.geolocation) {
+      setShowErrorBanner(true)
       setError("Tu navegador no soporta geolocalización.")
       return
     }
 
     setError(null)
+    setShowErrorBanner(false)
     navigator.geolocation.getCurrentPosition(
       (position) => {
         const { latitude, longitude } = position.coords
@@ -1152,6 +1213,7 @@ export default function MapComponent({
         })
       },
       () => {
+        setShowErrorBanner(true)
         setError("No se pudo obtener tu ubicación. Revisa permisos de GPS e inténtalo de nuevo.")
       },
       {
@@ -1280,7 +1342,18 @@ export default function MapComponent({
           Fabio A. Espinosa
         </Button>
       </div>
-      {error && <div className="absolute top-0 left-0 right-0 bg-red-500 text-white p-2 text-center z-10">{error}</div>}
+      {error && showErrorBanner && (
+        <div className="absolute top-0 left-0 right-0 bg-red-500 text-white p-2 z-10 flex items-center justify-between gap-2">
+          <span className="text-sm">{error}</span>
+          <button
+            type="button"
+            onClick={() => setShowErrorBanner(false)}
+            className="px-2 py-1 text-xs font-semibold bg-red-700 rounded hover:bg-red-800"
+          >
+            Cerrar
+          </button>
+        </div>
+      )}
 
       <style jsx global>{`
             .map-label {

--- a/app/components.jsx
+++ b/app/components.jsx
@@ -49,9 +49,11 @@ export default function Component() {
   const inputRef = useRef(null)
   const [showTitleLayer, setShowTitleLayer] = useState(false)
   const [showRequestLayer, setShowRequestLayer] = useState(false)
+  const [showAnmServiceLayer, setShowAnmServiceLayer] = useState(false)
   const [showHistoricalTitleLayer, setShowHistoricalTitleLayer] = useState(false)
   const [titleOpacity, setTitleOpacity] = useState(0.6)
   const [requestOpacity, setRequestOpacity] = useState(0.7)
+  const [anmServiceOpacity, setAnmServiceOpacity] = useState(0.7)
   const [historicalTitleOpacity, setHistoricalTitleOpacity] = useState(0.5)
 
   const handleApply = useCallback(() => {
@@ -132,20 +134,38 @@ export default function Component() {
     setIsLoading(true)
     setError(null)
     try {
+      const sanitizedQuery = query.trim().toUpperCase().replace(/'/g, "''")
+      const whereClause = `(UPPER(TENURE_ID) LIKE '${sanitizedQuery}%' OR UPPER(CODIGO_EXPEDIENTE) LIKE '${sanitizedQuery}%')`
       const urls = [
-        `https://annamineria.anm.gov.co/annageo/rest/services/SIGM/TenureLayers/MapServer/3/query?where=TENURE_ID%20LIKE%20'${query}%'&outFields=CODIGO_EXPEDIENTE&returnGeometry=false&f=json`,
-        `https://annamineria.anm.gov.co/annageo/rest/services/SIGM/TenureLayers/MapServer/4/query?where=TENURE_ID%20LIKE%20'${query}%'&outFields=CODIGO_EXPEDIENTE&returnGeometry=false&f=json`,
+        `https://annamineria.anm.gov.co/annageo/rest/services/SIGM/TenureLayers/MapServer/3/query?where=${encodeURIComponent(whereClause)}&outFields=CODIGO_EXPEDIENTE,TENURE_ID&returnGeometry=false&f=json`,
+        `https://annamineria.anm.gov.co/annageo/rest/services/SIGM/TenureLayers/MapServer/4/query?where=${encodeURIComponent(whereClause)}&outFields=CODIGO_EXPEDIENTE,TENURE_ID&returnGeometry=false&f=json`,
+        `https://geo.anm.gov.co/webgis/rest/services/ANM/ServiciosANM/MapServer/3/query?where=${encodeURIComponent(whereClause)}&outFields=CODIGO_EXPEDIENTE,TENURE_ID&returnGeometry=false&f=json`,
+        `https://annamineria.anm.gov.co/annageo/rest/services/SIGM/VisorInterno/MapServer/87/query?where=${encodeURIComponent(whereClause)}&outFields=CODIGO_EXPEDIENTE,TENURE_ID&returnGeometry=false&f=json`,
       ]
 
-      const responses = await Promise.all(urls.map((url) => fetch(url)))
-      const data = await Promise.all(responses.map((res) => res.json()))
+      const settledResponses = await Promise.allSettled(urls.map((url) => fetch(url)))
+      const successfulResponses = settledResponses
+        .filter((result) => result.status === "fulfilled" && result.value.ok)
+        .map((result) => result.value)
 
-      const expedients = data.flatMap((d) => d.features.map((f) => f.attributes.CODIGO_EXPEDIENTE))
+      const settledPayloads = await Promise.allSettled(successfulResponses.map((res) => res.json()))
+      const data = settledPayloads
+        .filter((result) => result.status === "fulfilled")
+        .map((result) => result.value)
+
+      const expedients = data.flatMap((d) =>
+        (d.features || [])
+          .map((f) => f.attributes?.CODIGO_EXPEDIENTE || f.attributes?.TENURE_ID)
+          .filter(Boolean),
+      )
       const uniqueExpedients = [...new Set(expedients)]
       if (uniqueExpedients.length > 0) {
         setExpedientSuggestions(uniqueExpedients.slice(0, 10))
       } else {
         setExpedientSuggestions([])
+      }
+      if (successfulResponses.length === 0) {
+        throw new Error("No fue posible consultar las capas de sugerencias.")
       }
     } catch (error) {
       console.error("Error fetching expedients:", error)
@@ -290,6 +310,21 @@ export default function Component() {
               <Switch id="requestLayer" checked={showRequestLayer} onCheckedChange={setShowRequestLayer} />
             </div>
             <div className="flex items-center gap-2">
+              <Label htmlFor="anmServiceLayer" className="text-sm">
+                Subcontratos
+              </Label>
+              <input
+                type="range"
+                min="0"
+                max="1"
+                step="0.1"
+                value={anmServiceOpacity}
+                onChange={(e) => setAnmServiceOpacity(parseFloat(e.target.value))}
+                className="flex-1"
+              />
+              <Switch id="anmServiceLayer" checked={showAnmServiceLayer} onCheckedChange={setShowAnmServiceLayer} />
+            </div>
+            <div className="flex items-center gap-2">
               <Label htmlFor="historicalTitleLayer" className="text-sm">
                 Título Histórico
               </Label>
@@ -347,9 +382,11 @@ export default function Component() {
           onMapInitialized={handleMapInitialized}
           showTitleLayer={showTitleLayer}
           showRequestLayer={showRequestLayer}
+          showAnmServiceLayer={showAnmServiceLayer}
           showHistoricalTitleLayer={showHistoricalTitleLayer}
           titleOpacity={titleOpacity}
           requestOpacity={requestOpacity}
+          anmServiceOpacity={anmServiceOpacity}
           historicalTitleOpacity={historicalTitleOpacity}
         />
         {!showSidebar && (


### PR DESCRIPTION
### Motivation

- Add support for an additional ANM map layer (ServiciosANM / Subcontratos) and expose toggle/opacity controls for it.
- Improve expedient search robustness by normalizing/sanitizing queries and searching multiple map services for suggestions and features.
- Make network failures and missing-results visible to users via a dismissible error banner.

### Description

- Added new props and state to `MapComponent` and parent `components.jsx`: `showAnmServiceLayer`, `anmServiceOpacity`, related refs, and `showErrorBanner` for a dismissible error UI.
- In `MapComponent`, normalized `expedientCode` input and added the ANM service query URL to the `fetchData` layer list so the main feature lookup includes the ServiciosANM source; added style and opacity handling for the new layer and applied its opacity on `zoomend`.
- Updated dynamic layer loading logic to include the new ANM layer via `EsriLeaflet.featureLayer`, wired the new toggle/slider UI from `components.jsx` to the map component, and added a close button to the error banner.
- Hardened suggestion fetching in `components.jsx` by sanitizing queries, adding the new service URLs, using `Promise.allSettled` to tolerate partial failures, aggregating/deduplicating results, and surfacing an error when no suggestion sources respond.

### Testing

- No automated tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0265a51038832eb2b6a71899b0e083)