### PR TITLE
Corregir ubicación y texto de las etiquetas del mapa

### DIFF
--- a/app/hooks/map/useExpedientSearch.js
+++ b/app/hooks/map/useExpedientSearch.js
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useCallback } from "react"
 import L from "leaflet"
-import { getLabelCoordinates, createPopupContent } from "../../utils/mapUtils"
+import { getLabelCoordinates, getFeatureLabel, createPopupContent } from "../../utils/mapUtils"
 
 export const useExpedientSearch = (
   mapRef,
@@ -80,20 +80,23 @@ export const useExpedientSearch = (
               style: layer.style,
               onEachFeature: (feature, layer) => {
                 const bestPoint = getLabelCoordinates(feature)
-                const [long, lat] = bestPoint
 
-                const label = L.divIcon({
-                  className: "map-label",
-                  html: `<div>${feature.properties.TENURE_ID}</div>`,
-                  iconSize: [100, 40],
-                  iconAnchor: [50, 20],
-                })
+                if (bestPoint) {
+                  const [long, lat] = bestPoint
 
-                if (!labelsLayerRef.current) {
-                  labelsLayerRef.current = L.layerGroup()
+                  const label = L.divIcon({
+                    className: "map-label",
+                    html: `<div>${getFeatureLabel(feature.properties)}</div>`,
+                    iconSize: [100, 40],
+                    iconAnchor: [50, 20],
+                  })
+
+                  if (!labelsLayerRef.current) {
+                    labelsLayerRef.current = L.layerGroup()
+                  }
+                  const marker = L.marker([lat, long], { icon: label })
+                  labelsLayerRef.current.addLayer(marker)
                 }
-                const marker = L.marker([lat, long], { icon: label })
-                labelsLayerRef.current.addLayer(marker)
 
                 const popupContent = createPopupContent(feature.properties)
                 layer.bindPopup(popupContent)

--- a/app/hooks/map/useMapLayers.js
+++ b/app/hooks/map/useMapLayers.js
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useCallback } from "react"
 import L from "leaflet"
 import * as EsriLeaflet from "esri-leaflet"
-import { getLabelCoordinates, createPopupContent } from "../../utils/mapUtils"
+import { getLabelCoordinates, getFeatureLabel, createPopupContent } from "../../utils/mapUtils"
 
 export const useMapLayers = (
   mapRef,
@@ -100,20 +100,23 @@ export const useMapLayers = (
             style: layerStyle,
             onEachFeature: (feature, layer) => {
               const bestPoint = getLabelCoordinates(feature)
-              const [long, lat] = bestPoint
 
-              const label = L.divIcon({
-                className: "map-label",
-                html: `<div>${feature.properties.TENURE_ID || "N/A"}</div>`,
-                iconSize: [100, 40],
-                iconAnchor: [50, 20],
-              })
+              if (bestPoint) {
+                const [long, lat] = bestPoint
 
-              if (!labelsLayerRef.current) {
-                labelsLayerRef.current = L.layerGroup()
+                const label = L.divIcon({
+                  className: "map-label",
+                  html: `<div>${getFeatureLabel(feature.properties)}</div>`,
+                  iconSize: [100, 40],
+                  iconAnchor: [50, 20],
+                })
+
+                if (!labelsLayerRef.current) {
+                  labelsLayerRef.current = L.layerGroup()
+                }
+                const marker = L.marker([lat, long], { icon: label })
+                labelsLayerRef.current.addLayer(marker)
               }
-              const marker = L.marker([lat, long], { icon: label })
-              labelsLayerRef.current.addLayer(marker)
 
               const popupContent = createPopupContent(feature.properties)
               layer.bindPopup(popupContent)
@@ -129,8 +132,13 @@ export const useMapLayers = (
           layerRef.current.setStyle(layerStyle)
         }
       } else if (layerRef.current) {
-        if (labelsLayerRef.current && mapRef.current.hasLayer(labelsLayerRef.current)) {
-          mapRef.current.removeLayer(labelsLayerRef.current)
+        // Anular el ref siempre, no solo cuando el grupo está en el mapa: fuera del
+        // rango de zoom de etiquetas nunca lo está, y conservarlo hacía que al
+        // reencender la capa los marcadores nuevos se apilaran sobre los viejos.
+        if (labelsLayerRef.current) {
+          if (mapRef.current.hasLayer(labelsLayerRef.current)) {
+            mapRef.current.removeLayer(labelsLayerRef.current)
+          }
           labelsLayerRef.current = null
         }
         if (mapRef.current.hasLayer(layerRef.current)) {

--- a/app/utils/mapUtils.js
+++ b/app/utils/mapUtils.js
@@ -38,59 +38,122 @@ export const formatDate = (value) => {
   return value || "N/A"
 }
 
+// Un anillo GeoJSON válido necesita al menos 4 posiciones (la última repite la primera).
+const MIN_RING_POSITIONS = 4
+// polylabel se detiene cuando ya no puede mejorar más que la precisión pedida.
+// Una milésima del tamaño del polígono da una posición sub-métrica sin encarecer el cálculo.
+const LABEL_PRECISION_RATIO = 1 / 1000
+const MIN_LABEL_PRECISION = 1e-7
+
+const isUsableRing = (ring) => Array.isArray(ring) && ring.length >= MIN_RING_POSITIONS
+
+const usableRingsOf = (rings) => (Array.isArray(rings) ? rings.filter(isUsableRing) : [])
+
 /**
- * Función auxiliar para obtener un punto interno usando polylabel
- * @param {Object} feature - GeoJSON Feature (Polygon o MultiPolygon)
- * @returns {Array} [long, lat] del punto más "interno" del polígono
+ * polylabel interpreta la precisión en las mismas unidades que las coordenadas.
+ * Trabajando en grados, un valor fijo como 0.1 equivale a ~11 km: el algoritmo se
+ * detiene en la primera iteración y devuelve un vértice del borde en lugar de un
+ * punto interior. Escalarla al tamaño del polígono la hace correcta a cualquier escala.
+ */
+const precisionForRing = (ring) => {
+  let minX = Infinity
+  let minY = Infinity
+  let maxX = -Infinity
+  let maxY = -Infinity
+
+  for (const [x, y] of ring) {
+    if (x < minX) minX = x
+    if (x > maxX) maxX = x
+    if (y < minY) minY = y
+    if (y > maxY) maxY = y
+  }
+
+  const size = Math.max(maxX - minX, maxY - minY)
+  if (!Number.isFinite(size) || size <= 0) {
+    return MIN_LABEL_PRECISION
+  }
+  return Math.max(size * LABEL_PRECISION_RATIO, MIN_LABEL_PRECISION)
+}
+
+const interiorPointOf = (rings) => {
+  const validRings = usableRingsOf(rings)
+  if (validRings.length === 0) {
+    return null
+  }
+
+  const candidate = polylabel(validRings, precisionForRing(validRings[0]))
+  const point = [candidate[0], candidate[1]]
+
+  // `ignoreBoundary` es imprescindible: sin él un punto que cae justo sobre el borde
+  // cuenta como interior y el respaldo nunca se activa.
+  const isInside = turf.booleanPointInPolygon(turf.point(point), turf.polygon(validRings), {
+    ignoreBoundary: true,
+  })
+
+  return isInside ? point : turf.pointOnFeature(turf.polygon(validRings)).geometry.coordinates
+}
+
+/**
+ * Punto interior donde anclar la etiqueta de una feature.
+ * Nunca lanza: esri-leaflet aborta el lote completo de features si `onEachFeature` falla.
+ * @param {Object} feature - GeoJSON Feature
+ * @returns {Array|null} [long, lat], o null si la geometría no permite ubicar la etiqueta
  */
 export const getLabelCoordinates = (feature) => {
-  const { type, coordinates } = feature.geometry
+  try {
+    const geometry = feature?.geometry
+    if (!geometry) {
+      return null
+    }
 
-  if (type === "Polygon") {
-    let bestPoint = polylabel(coordinates, 0.1)
-    if (
-      !turf.booleanPointInPolygon(
-        turf.point(bestPoint),
-        turf.polygon(coordinates),
-      )
-    ) {
-      bestPoint = turf.pointOnFeature(feature).geometry.coordinates
+    const { type, coordinates } = geometry
+
+    if (type === "Polygon") {
+      return interiorPointOf(coordinates)
     }
-    return bestPoint
-  } else if (type === "MultiPolygon") {
-    let largestArea = 0
-    let bestOverallPoint = [0, 0]
-    let polygonForBestPoint = null
-    for (const polygonCoords of coordinates) {
-      let labelPoint = polylabel(polygonCoords, 0.1)
-      if (
-        !turf.booleanPointInPolygon(
-          turf.point(labelPoint),
-          turf.polygon(polygonCoords),
-        )
-      ) {
-        labelPoint = turf.pointOnFeature(turf.polygon(polygonCoords)).geometry.coordinates
-      }
-      const area = turf.area(turf.polygon(polygonCoords))
-      if (area > largestArea) {
+
+    if (type === "MultiPolygon") {
+      let bestPoint = null
+      let largestArea = 0
+
+      for (const polygonCoords of coordinates) {
+        const rings = usableRingsOf(polygonCoords)
+        if (rings.length === 0) {
+          continue
+        }
+
+        const area = turf.area(turf.polygon(rings))
+        if (bestPoint && area <= largestArea) {
+          continue
+        }
+
+        const point = interiorPointOf(rings)
+        if (!point) {
+          continue
+        }
+
+        bestPoint = point
         largestArea = area
-        bestOverallPoint = labelPoint
-        polygonForBestPoint = polygonCoords
       }
+
+      return bestPoint
     }
-    if (
-      polygonForBestPoint &&
-      !turf.booleanPointInPolygon(
-        turf.point(bestOverallPoint),
-        turf.polygon(polygonForBestPoint),
-      )
-    ) {
-      bestOverallPoint = turf.pointOnFeature(feature).geometry.coordinates
-    }
-    return bestOverallPoint
+
+    // Puntos, líneas y demás: un punto sobre la geometría es mejor que [0, 0],
+    // que dejaba la etiqueta en la Isla Nula (0°N 0°E).
+    return turf.pointOnFeature(feature).geometry.coordinates
+  } catch (error) {
+    console.error("No se pudo calcular la posición de la etiqueta:", error)
+    return null
   }
-  return [0, 0]
 }
+
+/**
+ * Texto de la etiqueta. Las capas de Subcontratos e Histórico no exponen TENURE_ID,
+ * por eso el respaldo a CODIGO_EXPEDIENTE.
+ */
+export const getFeatureLabel = (properties) =>
+  properties?.TENURE_ID || properties?.CODIGO_EXPEDIENTE || "N/A"
 
 export const createPopupContent = (properties) => {
   return `

--- a/app/utils/mapUtils.test.js
+++ b/app/utils/mapUtils.test.js
@@ -1,0 +1,139 @@
+import * as turf from "@turf/turf"
+import { getLabelCoordinates, getFeatureLabel } from "./mapUtils"
+
+const polygonFeature = (coordinates) => ({
+  type: "Feature",
+  properties: {},
+  geometry: { type: "Polygon", coordinates },
+})
+
+// Título minero típico: cuadrado de ~3 km de lado cerca de Medellín.
+const SQUARE_3KM = [
+  [
+    [-75.6, 6.2],
+    [-75.57, 6.2],
+    [-75.57, 6.23],
+    [-75.6, 6.23],
+    [-75.6, 6.2],
+  ],
+]
+
+// Polígono cóncavo en "L": el centroide cae fuera, así que exige un punto interior real.
+const L_SHAPE = [
+  [
+    [-75.6, 6.2],
+    [-75.57, 6.2],
+    [-75.57, 6.23],
+    [-75.585, 6.23],
+    [-75.585, 6.21],
+    [-75.6, 6.21],
+    [-75.6, 6.2],
+  ],
+]
+
+describe("getLabelCoordinates", () => {
+  it.each([
+    ["cuadrado de 3 km", SQUARE_3KM],
+    ["polígono cóncavo en L", L_SHAPE],
+    ["polígono pequeño de 500 m", [[[-74.1, 4.6], [-74.0955, 4.6], [-74.0955, 4.6045], [-74.1, 4.6045], [-74.1, 4.6]]]],
+  ])("ubica la etiqueta estrictamente dentro de un %s", (_name, coordinates) => {
+    const point = getLabelCoordinates(polygonFeature(coordinates))
+
+    expect(point).not.toBeNull()
+    expect(
+      turf.booleanPointInPolygon(turf.point([point[0], point[1]]), turf.polygon(coordinates), {
+        ignoreBoundary: true,
+      }),
+    ).toBe(true)
+  })
+
+  it("no devuelve un vértice del borde (regresión: polylabel con precisión de 0.1°)", () => {
+    const point = getLabelCoordinates(polygonFeature(SQUARE_3KM))
+    const corners = SQUARE_3KM[0]
+
+    corners.forEach((corner) => {
+      expect(turf.distance(turf.point([point[0], point[1]]), turf.point(corner), { units: "meters" })).toBeGreaterThan(
+        100,
+      )
+    })
+  })
+
+  it("queda a menos de un metro del punto interior óptimo", () => {
+    const point = getLabelCoordinates(polygonFeature(SQUARE_3KM))
+    const optimal = turf.centerOfMass(turf.polygon(SQUARE_3KM)).geometry.coordinates
+
+    expect(
+      turf.distance(turf.point([point[0], point[1]]), turf.point(optimal), { units: "meters" }),
+    ).toBeLessThan(1)
+  })
+
+  it("elige la parte más grande de un MultiPolygon", () => {
+    const small = [[[-75.5, 6.3], [-75.499, 6.3], [-75.499, 6.301], [-75.5, 6.301], [-75.5, 6.3]]]
+    const feature = {
+      type: "Feature",
+      properties: {},
+      geometry: { type: "MultiPolygon", coordinates: [small, SQUARE_3KM] },
+    }
+
+    const point = getLabelCoordinates(feature)
+
+    expect(
+      turf.booleanPointInPolygon(turf.point([point[0], point[1]]), turf.polygon(SQUARE_3KM), {
+        ignoreBoundary: true,
+      }),
+    ).toBe(true)
+  })
+
+  it("ignora las partes degeneradas de un MultiPolygon en vez de lanzar", () => {
+    const degenerate = [[[-75.5, 6.3], [-75.499, 6.3], [-75.5, 6.3]]]
+    const feature = {
+      type: "Feature",
+      properties: {},
+      geometry: { type: "MultiPolygon", coordinates: [degenerate, SQUARE_3KM] },
+    }
+
+    const point = getLabelCoordinates(feature)
+
+    expect(
+      turf.booleanPointInPolygon(turf.point([point[0], point[1]]), turf.polygon(SQUARE_3KM), {
+        ignoreBoundary: true,
+      }),
+    ).toBe(true)
+  })
+
+  it("devuelve null en vez de lanzar cuando el anillo es degenerado", () => {
+    // Antes turf.polygon lanzaba aquí y esri-leaflet abortaba el lote completo de features.
+    expect(getLabelCoordinates(polygonFeature([[[-75.6, 6.2], [-75.57, 6.2], [-75.6, 6.2]]]))).toBeNull()
+  })
+
+  it("devuelve null para geometrías ausentes o vacías", () => {
+    expect(getLabelCoordinates(undefined)).toBeNull()
+    expect(getLabelCoordinates({ type: "Feature", properties: {} })).toBeNull()
+    expect(getLabelCoordinates(polygonFeature([]))).toBeNull()
+  })
+
+  it("usa la propia geometría para un punto, no la Isla Nula", () => {
+    const feature = {
+      type: "Feature",
+      properties: {},
+      geometry: { type: "Point", coordinates: [-75.5, 6.2] },
+    }
+
+    expect(getLabelCoordinates(feature)).toEqual([-75.5, 6.2])
+  })
+})
+
+describe("getFeatureLabel", () => {
+  it("prefiere TENURE_ID", () => {
+    expect(getFeatureLabel({ TENURE_ID: "ABC-123", CODIGO_EXPEDIENTE: "XYZ" })).toBe("ABC-123")
+  })
+
+  it("cae a CODIGO_EXPEDIENTE en las capas que no exponen TENURE_ID", () => {
+    expect(getFeatureLabel({ CODIGO_EXPEDIENTE: "XYZ-987" })).toBe("XYZ-987")
+  })
+
+  it("devuelve N/A sin lanzar cuando no hay propiedades", () => {
+    expect(getFeatureLabel(undefined)).toBe("N/A")
+    expect(getFeatureLabel({})).toBe("N/A")
+  })
+})

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,4 +12,18 @@ const customJestConfig = {
 }
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
-module.exports = createJestConfig(customJestConfig)
+const jestConfig = createJestConfig(customJestConfig)
+
+module.exports = async () => {
+  const config = await jestConfig()
+
+  // next/jest solo permite *añadir* a transformIgnorePatterns, y su primera entrada
+  // (`/node_modules/`) gana siempre. polylabel y su dependencia tinyqueue se publican
+  // únicamente como ESM, así que hay que reemplazar la lista para poder transformarlos.
+  config.transformIgnorePatterns = [
+    '/node_modules/(?!(polylabel|tinyqueue)/)',
+    '^.+\\.module\\.(css|sass|scss)$',
+  ]
+
+  return config
+}


### PR DESCRIPTION
polylabel interpreta la precisión en las mismas unidades que las coordenadas. Al trabajar en grados, el valor fijo de 0.1 equivalía a ~11 km, así que para cualquier polígono más pequeño que eso el algoritmo se detenía en la primera iteración y devolvía un vértice del borde en lugar de un punto interior. La etiqueta quedaba entre 350 m y 4,5 km fuera de sitio en los tamaños típicos de un título minero.

El respaldo con booleanPointInPolygon que debía atrapar esos casos nunca se activaba, porque por defecto un punto sobre el borde cuenta como interior.

- Escalar la precisión de polylabel al tamaño del polígono.
- Pasar ignoreBoundary al comprobar si el punto quedó dentro.
- Hacer que getLabelCoordinates nunca lance: una geometría degenerada hacía que turf.polygon lanzara desde onEachFeature, y esri-leaflet aborta el lote completo de features cuando eso ocurre. Ahora devuelve null y la capa se dibuja sin esa etiqueta.
- Usar un punto sobre la geometría para tipos no poligonales, en vez de [0, 0], que dejaba la etiqueta en 0°N 0°E.
- Añadir getFeatureLabel con respaldo a CODIGO_EXPEDIENTE: las capas de Subcontratos e Histórico no exponen TENURE_ID y sus etiquetas salían como "N/A" en el mapa y "undefined" en la búsqueda.
- Anular labelsLayerRef al apagar una capa aunque el grupo no esté en el mapa. Fuera del rango de zoom de etiquetas nunca lo está, y conservarlo hacía que al reencender la capa los marcadores se apilaran sobre los anteriores.

Reemplazar transformIgnorePatterns en jest.config: next/jest solo permite añadir entradas y su `/node_modules/` gana siempre, pero polylabel y tinyqueue se publican únicamente como ESM.


Claude-Session: https://claude.ai/code/session_01LzwXzKx1PSKSBVx7Wfu3uQ