### PR TITLE
Corregir etiquetas acumuladas, buscador de expedientes y herramientas de dibujo

### DIFF
--- a/app/MapComponent.jsx
+++ b/app/MapComponent.jsx
@@ -61,7 +61,6 @@ export default function MapComponent({
   } = useGeolocation(mapRef, setError, setShowErrorBanner)
 
   const {
-    findLayerNumbers,
     showZoomInHint,
     titleLabelsLayerRef,
     requestLabelsLayerRef,
@@ -88,7 +87,6 @@ export default function MapComponent({
     expedientCode,
     searchTrigger,
     onCoordinatesUpdate,
-    findLayerNumbers,
     setError,
     setShowErrorBanner,
     geoJsonLayerRef,

--- a/app/MapComponent.jsx
+++ b/app/MapComponent.jsx
@@ -12,6 +12,7 @@ import { useGeolocation } from "./hooks/map/useGeolocation"
 import { useMapLayers } from "./hooks/map/useMapLayers"
 import { useExpedientSearch } from "./hooks/map/useExpedientSearch"
 import { formatDistance, formatArea, formatDegrees } from "./utils/mapUtils"
+import { shouldShowLabels } from "./utils/mapLabels"
 import { MapControls } from "./components/MapControls"
 import { ColorPicker } from "./components/ColorPicker"
 
@@ -223,25 +224,22 @@ export default function MapComponent({
       })
 
       const handleZoom = () => {
-        const currentZoom = mapInstanceLocal.getZoom()
+        // Solo las capas masivas se ocultan por zoom. La etiqueta del expediente
+        // buscado permanece visible: es un único resultado que el usuario pidió.
+        const showLabels = shouldShowLabels(mapInstanceLocal.getZoom())
         const labelsLayers = [
-          labelsLayerRef.current,
           titleLabelsLayerRef.current,
           requestLabelsLayerRef.current,
           anmServiceLabelsLayerRef.current,
           historicalTitleLabelsLayerRef.current,
         ]
+
         labelsLayers.forEach((layer) => {
-          if (layer) {
-            if (currentZoom >= 15 && currentZoom <= 19) {
-              if (!mapInstanceLocal.hasLayer(layer)) {
-                mapInstanceLocal.addLayer(layer)
-              }
-            } else {
-              if (mapInstanceLocal.hasLayer(layer)) {
-                mapInstanceLocal.removeLayer(layer)
-              }
-            }
+          if (!layer) return
+          if (showLabels && !mapInstanceLocal.hasLayer(layer)) {
+            mapInstanceLocal.addLayer(layer)
+          } else if (!showLabels && mapInstanceLocal.hasLayer(layer)) {
+            mapInstanceLocal.removeLayer(layer)
           }
         })
 

--- a/app/MapComponent.jsx
+++ b/app/MapComponent.jsx
@@ -34,6 +34,7 @@ export default function MapComponent({
   const drawControlRef = useRef(null)
   const drawnItemsRef = useRef(null)
   const measureControlRef = useRef(null)
+  const activeMeasureRef = useRef(null)
   const geoJsonLayerRef = useRef(null)
   const verticesLayerRef = useRef(null)
   const labelsLayerRef = useRef(null)
@@ -46,10 +47,11 @@ export default function MapComponent({
 
   const {
     drawingColor,
+    drawingColorRef,
     handleColorChange,
     showColorPicker,
     setShowColorPicker
-  } = useDrawControl(mapRef, drawControlRef, drawnItemsRef)
+  } = useDrawControl(mapRef, mapInstance, drawControlRef, drawnItemsRef, measureControlRef)
 
   const {
     isLocating,
@@ -115,58 +117,32 @@ export default function MapComponent({
       drawnItemsRef.current = new L.FeatureGroup()
       mapInstanceLocal.addLayer(drawnItemsRef.current)
 
-      const markerIcon = new L.Icon({
-        iconUrl: "https://unpkg.com/leaflet@1.7.1/dist/images/marker-icon.png",
-        iconRetinaUrl: "https://unpkg.com/leaflet@1.7.1/dist/images/marker-icon-2x.png",
-        shadowUrl: "https://unpkg.com/leaflet@1.7.1/dist/images/marker-shadow.png",
-        iconSize: [25, 41],
-        iconAnchor: [12, 41],
-        popupAnchor: [1, -34],
-        shadowSize: [41, 41],
-      })
+      // El control de dibujo lo crea useDrawControl, que también lo recrea cuando
+      // cambia el color; aquí se duplicaban sus cincuenta líneas de opciones.
 
-      drawControlRef.current = new L.Control.Draw({
-        position: "topright",
-        draw: {
-          polyline: {
-            shapeOptions: { color: drawingColor, weight: 5 },
-          },
-          polygon: {
-            allowIntersection: false,
-            drawError: {
-              color: "#e1e100",
-              message: "<strong>¡Error!</strong> No se permiten polígonos que se intersecten.",
-            },
-            shapeOptions: { color: drawingColor },
-          },
-          circle: { shapeOptions: { color: drawingColor } },
-          rectangle: { shapeOptions: { color: drawingColor } },
-          marker: { icon: markerIcon },
-          circlemarker: false,
-        },
-        edit: {
-          featureGroup: drawnItemsRef.current,
-          remove: true,
-        },
-      })
-
-      mapInstanceLocal.addControl(drawControlRef.current)
-
-      const startDistanceMeasure = () => {
-        const drawer = new L.Draw.Polyline(mapInstanceLocal, {
-          shapeOptions: { color: drawingColor, weight: 5 },
-        })
+      // Cada clic en medir habilitaba un dibujante nuevo sin apagar el anterior, y
+      // el color se leía del primer render. El ref resuelve lo segundo.
+      const startMeasure = (createDrawer) => {
+        activeMeasureRef.current?.disable()
+        const drawer = createDrawer(drawingColorRef.current)
         drawer.enable()
+        activeMeasureRef.current = drawer
       }
 
-      const startAreaMeasure = () => {
-        const drawer = new L.Draw.Polygon(mapInstanceLocal, {
-          allowIntersection: false,
-          showArea: true,
-          shapeOptions: { color: drawingColor },
-        })
-        drawer.enable()
-      }
+      const startDistanceMeasure = () =>
+        startMeasure(
+          (color) => new L.Draw.Polyline(mapInstanceLocal, { shapeOptions: { color, weight: 5 } }),
+        )
+
+      const startAreaMeasure = () =>
+        startMeasure(
+          (color) =>
+            new L.Draw.Polygon(mapInstanceLocal, {
+              allowIntersection: false,
+              showArea: true,
+              shapeOptions: { color },
+            }),
+        )
 
       const MeasureControl = L.Control.extend({
         options: { position: "topright" },
@@ -203,6 +179,7 @@ export default function MapComponent({
 
       mapInstanceLocal.on(L.Draw.Event.CREATED, (event) => {
         const layer = event.layer
+        activeMeasureRef.current = null
         drawnItemsRef.current.addLayer(layer)
 
         if (event.layerType === "polyline") {

--- a/app/components.jsx
+++ b/app/components.jsx
@@ -36,7 +36,9 @@ const MAX_SUGGESTIONS = 10
 /** Etiqueta, slider de opacidad e interruptor de una capa. */
 const LayerControl = ({ id, label, checked, onCheckedChange, opacity, onOpacityChange }) => (
   <>
-    <Label htmlFor={id} className="text-sm">
+    {/* Ancho fijo para que las cuatro filas queden alineadas: sin él la etiqueta más
+        larga partía en dos líneas y desnivelaba su fila. */}
+    <Label htmlFor={id} className="w-36 shrink-0 whitespace-nowrap text-sm">
       {label}
     </Label>
     <input
@@ -345,7 +347,9 @@ export default function Component() {
   return (
     <div className="relative flex w-full h-screen bg-gray-100">
       <div
-        className={`absolute top-4 left-4 z-10 w-[350px] bg-white shadow-lg rounded-xl transition-transform duration-300 ease-in-out ${showSidebar ? "translate-x-0" : "-translate-x-full"}`}
+        // -translate-x-full solo desplaza el ancho del panel, y al estar en left-4
+        // quedaba una franja de 16px asomando bajo el botón de mostrar.
+        className={`absolute top-4 left-4 z-10 w-[350px] bg-white shadow-lg rounded-xl transition-transform duration-300 ease-in-out ${showSidebar ? "translate-x-0" : "-translate-x-[calc(100%+1rem)]"}`}
       >
         <div className="p-4 space-y-4">
           <div className="flex items-center justify-between mb-4">

--- a/app/components.jsx
+++ b/app/components.jsx
@@ -12,6 +12,12 @@ import proj4 from "proj4"
 import ExportComponent from "./ExportComponent"
 import { formatDegrees } from "./utils/mapUtils"
 import { fetchArcgisJson } from "./utils/arcgis"
+import {
+  findTenureLayerNumbers,
+  REQUEST_LAYER_NAME,
+  TITLE_LAYER_NAME,
+  tenureLayerUrl,
+} from "./utils/tenureLayers"
 import { debounce } from "@/lib/utils"
 
 const MapComponent = dynamic(() => import("./MapComponent"), {
@@ -23,6 +29,31 @@ const MapComponent = dynamic(() => import("./MapComponent"), {
 const epsg4686 = "+proj=longlat +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +no_defs"
 const epsg9377 =
   "+proj=tmerc +lat_0=4.0 +lon_0=-73.0 +k=0.9992 +x_0=5000000 +y_0=2000000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs"
+
+const MIN_SUGGESTION_LENGTH = 3
+const MAX_SUGGESTIONS = 10
+
+/** Etiqueta, slider de opacidad e interruptor de una capa. */
+const LayerControl = ({ id, label, checked, onCheckedChange, opacity, onOpacityChange }) => (
+  <>
+    <Label htmlFor={id} className="text-sm">
+      {label}
+    </Label>
+    <input
+      type="range"
+      min="0"
+      max="1"
+      step="0.1"
+      value={opacity}
+      onChange={(e) => onOpacityChange(parseFloat(e.target.value))}
+      className="flex-1 disabled:opacity-40"
+      // El slider no hace nada con la capa apagada; deshabilitarlo lo deja claro.
+      disabled={!checked}
+      aria-label={`Opacidad de ${label}`}
+    />
+    <Switch id={id} checked={checked} onCheckedChange={onCheckedChange} />
+  </>
+)
 
 export default function Component() {
   const [showSidebar, setShowSidebar] = useState(true)
@@ -40,9 +71,13 @@ export default function Component() {
   const mapRef = useRef(null)
   const [mapInitialized, setMapInitialized] = useState(false)
   const [expedientSuggestions, setExpedientSuggestions] = useState([])
+  const [activeSuggestion, setActiveSuggestion] = useState(-1)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState(null)
   const inputRef = useRef(null)
+  const searchBoxRef = useRef(null)
+  const suggestionAbortRef = useRef(null)
+  const skipNextSuggestionFetchRef = useRef(false)
   const [showTitleLayer, setShowTitleLayer] = useState(false)
   const [showRequestLayer, setShowRequestLayer] = useState(false)
   const [showAnmServiceLayer, setShowAnmServiceLayer] = useState(false)
@@ -57,9 +92,67 @@ export default function Component() {
       alert("Por favor, introduce un código de expediente.")
       return
     }
+    setExpedientSuggestions([])
     setSearchTrigger((prev) => prev + 1)
     setShowToggle(true)
   }, [expedientCode])
+
+  const closeSuggestions = useCallback(() => {
+    setExpedientSuggestions([])
+    setActiveSuggestion(-1)
+  }, [])
+
+  const selectSuggestion = useCallback(
+    (suggestion) => {
+      skipNextSuggestionFetchRef.current = true
+      setExpedientCode(suggestion)
+      closeSuggestions()
+      inputRef.current?.focus()
+    },
+    [closeSuggestions],
+  )
+
+  const handleSearchKeyDown = useCallback(
+    (event) => {
+      if (event.key === "Escape") {
+        closeSuggestions()
+        return
+      }
+
+      if (expedientSuggestions.length === 0) {
+        if (event.key === "Enter") handleApply()
+        return
+      }
+
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        event.preventDefault()
+        const step = event.key === "ArrowDown" ? 1 : -1
+        setActiveSuggestion((current) => {
+          const next = current + step
+          if (next < 0) return expedientSuggestions.length - 1
+          if (next >= expedientSuggestions.length) return 0
+          return next
+        })
+        return
+      }
+
+      if (event.key === "Enter") {
+        event.preventDefault()
+        if (activeSuggestion >= 0) {
+          selectSuggestion(expedientSuggestions[activeSuggestion])
+        } else {
+          closeSuggestions()
+          handleApply()
+        }
+      }
+    },
+    [activeSuggestion, closeSuggestions, expedientSuggestions, handleApply, selectSuggestion],
+  )
+
+  // Reiniciar el resaltado cada vez que cambia la lista.
+  useEffect(() => {
+    setActiveSuggestion(-1)
+  }, [expedientSuggestions])
 
   const handleShowCoordinates = () => {
     if (coordinatesAvailable) {
@@ -145,22 +238,41 @@ export default function Component() {
   }, [])
 
   const fetchExpedients = useCallback(async (query) => {
+    // Cancelar la consulta anterior: sin esto una respuesta lenta podía llegar después
+    // de una más reciente y pisar sus sugerencias.
+    suggestionAbortRef.current?.abort()
+    const controller = new AbortController()
+    suggestionAbortRef.current = controller
+
     setIsLoading(true)
     setError(null)
     try {
       const sanitizedQuery = query.trim().toUpperCase().replace(/'/g, "''")
       const whereClause = `(UPPER(TENURE_ID) LIKE '${sanitizedQuery}%' OR UPPER(CODIGO_EXPEDIENTE) LIKE '${sanitizedQuery}%')`
+      const queryString = `query?where=${encodeURIComponent(whereClause)}&outFields=CODIGO_EXPEDIENTE,TENURE_ID&returnGeometry=false&f=json`
+
+      // Los números de las capas de tenencia se descubren, igual que en el mapa y en
+      // la búsqueda. Aquí estaban fijos en 3 y 4, y podían discrepar del resto.
+      const layerNumbers = await findTenureLayerNumbers()
+      if (controller.signal.aborted) return
+
       const urls = [
-        `https://annamineria.anm.gov.co/annageo/rest/services/SIGM/TenureLayers/MapServer/3/query?where=${encodeURIComponent(whereClause)}&outFields=CODIGO_EXPEDIENTE,TENURE_ID&returnGeometry=false&f=json`,
-        `https://annamineria.anm.gov.co/annageo/rest/services/SIGM/TenureLayers/MapServer/4/query?where=${encodeURIComponent(whereClause)}&outFields=CODIGO_EXPEDIENTE,TENURE_ID&returnGeometry=false&f=json`,
-        `https://geo.anm.gov.co/webgis/rest/services/ANM/ServiciosANM/MapServer/3/query?where=${encodeURIComponent(whereClause)}&outFields=CODIGO_EXPEDIENTE,TENURE_ID&returnGeometry=false&f=json`,
-        `https://annamineria.anm.gov.co/annageo/rest/services/SIGM/VisorInterno/MapServer/87/query?where=${encodeURIComponent(whereClause)}&outFields=CODIGO_EXPEDIENTE,TENURE_ID&returnGeometry=false&f=json`,
+        ...[TITLE_LAYER_NAME, REQUEST_LAYER_NAME]
+          .map((name) => layerNumbers[name])
+          .filter((layerNumber) => layerNumber !== undefined)
+          .map((layerNumber) => `${tenureLayerUrl(layerNumber)}/${queryString}`),
+        `https://geo.anm.gov.co/webgis/rest/services/ANM/ServiciosANM/MapServer/3/${queryString}`,
+        `https://annamineria.anm.gov.co/annageo/rest/services/SIGM/VisorInterno/MapServer/87/${queryString}`,
       ]
 
       // fetchArcgisJson reconoce los errores que ArcGIS devuelve con HTTP 200; antes
       // una capa que respondía {"error": ...} se contaba como consulta exitosa sin
       // resultados, y las sugerencias salían incompletas en silencio.
-      const settled = await Promise.allSettled(urls.map((url) => fetchArcgisJson(url)))
+      const settled = await Promise.allSettled(
+        urls.map((url) => fetchArcgisJson(url, { signal: controller.signal })),
+      )
+      if (controller.signal.aborted) return
+
       const data = settled.filter((result) => result.status === "fulfilled").map((result) => result.value)
 
       const expedients = data.flatMap((d) =>
@@ -169,16 +281,19 @@ export default function Component() {
           .filter(Boolean),
       )
       const uniqueExpedients = [...new Set(expedients)]
-      setExpedientSuggestions(uniqueExpedients.slice(0, 10))
+      setExpedientSuggestions(uniqueExpedients.slice(0, MAX_SUGGESTIONS))
 
       if (data.length === 0) {
         throw new Error("No fue posible consultar las capas de sugerencias.")
       }
     } catch (error) {
+      if (error?.name === "AbortError" || controller.signal.aborted) return
       console.error("Error fetching expedients:", error)
       setError("Error al cargar los expedientes. Por favor, intente de nuevo.")
     } finally {
-      setIsLoading(false)
+      if (!controller.signal.aborted) {
+        setIsLoading(false)
+      }
     }
   }, [])
 
@@ -188,32 +303,42 @@ export default function Component() {
   )
 
   useEffect(() => {
-    if (expedientCode.trim().length > 0) {
-      debouncedFetchExpedients(expedientCode)
-    } else {
-      setExpedientSuggestions([])
+    // Elegir una sugerencia cambia expedientCode, lo que volvía a disparar la consulta
+    // y reabría el desplegable 300 ms después de haberlo cerrado.
+    if (skipNextSuggestionFetchRef.current) {
+      skipNextSuggestionFetchRef.current = false
+      return
     }
+
+    // Con una sola letra, `LIKE 'A%'` barre el dataset nacional entero sin dar nada útil.
+    if (expedientCode.trim().length < MIN_SUGGESTION_LENGTH) {
+      suggestionAbortRef.current?.abort()
+      setExpedientSuggestions([])
+      setIsLoading(false)
+      return
+    }
+
+    debouncedFetchExpedients(expedientCode)
   }, [expedientCode, debouncedFetchExpedients])
 
   useEffect(() => {
+    // Contra el contenedor, no contra el input: el desplegable vive dentro y un clic
+    // en una sugerencia se contaba como clic fuera.
     const handleClickOutside = (event) => {
-      if (inputRef.current && !inputRef.current.contains(event.target)) {
-        setExpedientSuggestions([])
-      }
-    }
-
-    const handleEscapeKey = (event) => {
-      if (event.key === "Escape") {
-        setExpedientSuggestions([])
+      if (searchBoxRef.current && !searchBoxRef.current.contains(event.target)) {
+        closeSuggestions()
       }
     }
 
     document.addEventListener("click", handleClickOutside)
-    document.addEventListener("keydown", handleEscapeKey)
-
     return () => {
       document.removeEventListener("click", handleClickOutside)
-      document.removeEventListener("keydown", handleEscapeKey)
+    }
+  }, [closeSuggestions])
+
+  useEffect(() => {
+    return () => {
+      suggestionAbortRef.current?.abort()
     }
   }, [])
 
@@ -240,23 +365,26 @@ export default function Component() {
               <Label htmlFor="search" className="text-sm font-medium mb-1 block">
                 Buscar Expediente
               </Label>
-              <div className="relative">
+              {/* El desplegable vive dentro de este contenedor posicionado. Antes era
+                  hermano suyo, así que su ancho se medía contra la barra lateral
+                  completa y se desbordaba por el padding. */}
+              <div className="relative" ref={searchBoxRef}>
                 <Input
                   ref={inputRef}
                   id="search"
                   placeholder="Ingrese el expediente"
                   value={expedientCode}
-                  onChange={(e) => {
-                    const value = e.target.value.toUpperCase()
-                    setExpedientCode(value)
-                    if (!value.trim()) {
-                      setExpedientSuggestions([])
-                    }
-                  }}
+                  onChange={(e) => setExpedientCode(e.target.value.toUpperCase())}
+                  onKeyDown={handleSearchKeyDown}
                   className="pl-10 pr-4 py-2 w-full border rounded-md"
+                  role="combobox"
+                  autoComplete="off"
                   aria-autocomplete="list"
                   aria-controls="expedient-suggestions"
                   aria-expanded={expedientSuggestions.length > 0}
+                  aria-activedescendant={
+                    activeSuggestion >= 0 ? `expedient-suggestion-${activeSuggestion}` : undefined
+                  }
                 />
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" size={18} />
                 {isLoading && (
@@ -264,27 +392,37 @@ export default function Component() {
                     <Loader2 className="h-5 w-5 animate-spin text-blue-500" />
                   </div>
                 )}
+                {expedientSuggestions.length > 0 && (
+                  <ul
+                    id="expedient-suggestions"
+                    role="listbox"
+                    aria-label="Expedientes sugeridos"
+                    className="absolute left-0 right-0 top-full z-20 mt-1 bg-white border rounded-md shadow-lg max-h-60 overflow-auto"
+                  >
+                    {expedientSuggestions.map((suggestion, index) => (
+                      <li
+                        key={suggestion}
+                        id={`expedient-suggestion-${index}`}
+                        role="option"
+                        aria-selected={index === activeSuggestion}
+                        className={`px-4 py-2 cursor-pointer ${
+                          index === activeSuggestion ? "bg-blue-50" : "hover:bg-gray-100"
+                        }`}
+                        // onMouseDown, no onClick: el clic fuera cierra la lista antes
+                        // de que llegue el onClick del elemento.
+                        onMouseDown={(event) => {
+                          event.preventDefault()
+                          selectSuggestion(suggestion)
+                        }}
+                        onMouseEnter={() => setActiveSuggestion(index)}
+                      >
+                        {suggestion}
+                      </li>
+                    ))}
+                  </ul>
+                )}
               </div>
               {error && <p className="text-red-500 text-sm mt-1">{error}</p>}
-              {expedientSuggestions.length > 0 && (
-                <ul
-                  id="expedient-suggestions"
-                  className="absolute z-20 w-full bg-white border mt-1 rounded-md shadow-lg max-h-60 overflow-auto"
-                >
-                  {expedientSuggestions.map((suggestion, index) => (
-                    <li
-                      key={index}
-                      className="px-4 py-2 hover:bg-gray-100 cursor-pointer"
-                      onClick={() => {
-                        setExpedientCode(suggestion)
-                        setExpedientSuggestions([])
-                      }}
-                    >
-                      {suggestion}
-                    </li>
-                  ))}
-                </ul>
-              )}
             </div>
           </div>
           <Button onClick={handleApply} className="w-full bg-blue-500 hover:bg-blue-600 text-white">
@@ -292,70 +430,43 @@ export default function Component() {
           </Button>
           <div className="space-y-4">
             <div className="flex items-center gap-2">
-              <Label htmlFor="titleLayer" className="text-sm">
-                Títulos Vigentes
-              </Label>
-              <input
-                type="range"
-                min="0"
-                max="1"
-                step="0.1"
-                value={titleOpacity}
-                onChange={(e) => setTitleOpacity(parseFloat(e.target.value))}
-                className="flex-1"
-                aria-label="Opacidad de Títulos Vigentes"
+              <LayerControl
+                id="titleLayer"
+                label="Títulos Vigentes"
+                checked={showTitleLayer}
+                onCheckedChange={setShowTitleLayer}
+                opacity={titleOpacity}
+                onOpacityChange={setTitleOpacity}
               />
-              <Switch id="titleLayer" checked={showTitleLayer} onCheckedChange={setShowTitleLayer} />
             </div>
             <div className="flex items-center gap-2">
-              <Label htmlFor="requestLayer" className="text-sm">
-                Solicitudes Vigente
-              </Label>
-                <input
-                  type="range"
-                  min="0"
-                  max="1"
-                  step="0.1"
-                  value={requestOpacity}
-                  onChange={(e) => setRequestOpacity(parseFloat(e.target.value))}
-                  className="flex-1"
-                  aria-label="Opacidad de Solicitudes Vigente"
-                />
-              <Switch id="requestLayer" checked={showRequestLayer} onCheckedChange={setShowRequestLayer} />
+              <LayerControl
+                id="requestLayer"
+                label="Solicitudes Vigentes"
+                checked={showRequestLayer}
+                onCheckedChange={setShowRequestLayer}
+                opacity={requestOpacity}
+                onOpacityChange={setRequestOpacity}
+              />
             </div>
             <div className="flex items-center gap-2">
-              <Label htmlFor="anmServiceLayer" className="text-sm">
-                Subcontratos
-              </Label>
-              <input
-                type="range"
-                min="0"
-                max="1"
-                step="0.1"
-                value={anmServiceOpacity}
-                onChange={(e) => setAnmServiceOpacity(parseFloat(e.target.value))}
-                className="flex-1"
+              <LayerControl
+                id="anmServiceLayer"
+                label="Subcontratos"
+                checked={showAnmServiceLayer}
+                onCheckedChange={setShowAnmServiceLayer}
+                opacity={anmServiceOpacity}
+                onOpacityChange={setAnmServiceOpacity}
               />
-              <Switch id="anmServiceLayer" checked={showAnmServiceLayer} onCheckedChange={setShowAnmServiceLayer} />
             </div>
             <div className="flex items-center gap-2">
-              <Label htmlFor="historicalTitleLayer" className="text-sm">
-                Título Histórico
-              </Label>
-              <input
-                type="range"
-                min="0"
-                max="1"
-                step="0.1"
-                value={historicalTitleOpacity}
-                onChange={(e) => setHistoricalTitleOpacity(parseFloat(e.target.value))}
-                className="flex-1"
-                aria-label="Opacidad de Título Histórico"
-              />
-              <Switch
+              <LayerControl
                 id="historicalTitleLayer"
+                label="Título Histórico"
                 checked={showHistoricalTitleLayer}
                 onCheckedChange={setShowHistoricalTitleLayer}
+                opacity={historicalTitleOpacity}
+                onOpacityChange={setHistoricalTitleOpacity}
               />
             </div>
           </div>

--- a/app/components.test.jsx
+++ b/app/components.test.jsx
@@ -1,0 +1,108 @@
+import React from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import Component from "./components"
+
+jest.mock("./MapComponent", () => ({
+  __esModule: true,
+  default: () => <div data-testid="map" />,
+}))
+
+jest.mock("./utils/tenureLayers", () => ({
+  ...jest.requireActual("./utils/tenureLayers"),
+  findTenureLayerNumbers: jest.fn(async () => ({ "Título Vigente": 3, "Solicitud Vigente": 4 })),
+}))
+
+const suggestionResponse = (codes) => ({
+  ok: true,
+  json: async () => ({ features: codes.map((code) => ({ attributes: { TENURE_ID: code } })) }),
+})
+
+const typeInSearch = async (user, text) => {
+  const input = screen.getByPlaceholderText("Ingrese el expediente")
+  await user.click(input)
+  await user.type(input, text)
+  return input
+}
+
+describe("buscador de expedientes", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(console, "error").mockImplementation(() => {})
+    global.fetch = jest.fn(async () => suggestionResponse(["ABC-123", "ABC-456"]))
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it("no consulta el servicio con menos de tres caracteres", async () => {
+    // Antes se disparaba en cada tecla: `LIKE 'A%'` barre el dataset nacional entero.
+    const user = userEvent.setup()
+    render(<Component />)
+
+    await typeInSearch(user, "AB")
+
+    await new Promise((resolve) => setTimeout(resolve, 400))
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it("muestra las sugerencias a partir de tres caracteres", async () => {
+    const user = userEvent.setup()
+    render(<Component />)
+
+    await typeInSearch(user, "ABC")
+
+    expect(await screen.findByRole("listbox")).toBeInTheDocument()
+    expect(screen.getAllByRole("option")).toHaveLength(2)
+  })
+
+  it("no reabre el desplegable después de elegir una sugerencia", async () => {
+    // Regresión: elegir una sugerencia actualizaba expedientCode, lo que volvía a
+    // disparar la consulta y reabría la lista 300 ms más tarde.
+    const user = userEvent.setup()
+    render(<Component />)
+
+    await typeInSearch(user, "ABC")
+    await user.click(await screen.findByText("ABC-123"))
+
+    expect(screen.getByPlaceholderText("Ingrese el expediente")).toHaveValue("ABC-123")
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+
+    await new Promise((resolve) => setTimeout(resolve, 400))
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+  })
+
+  it("permite elegir con el teclado", async () => {
+    const user = userEvent.setup()
+    render(<Component />)
+
+    await typeInSearch(user, "ABC")
+    await screen.findByRole("listbox")
+
+    await user.keyboard("{ArrowDown}{ArrowDown}")
+    expect(screen.getAllByRole("option")[1]).toHaveAttribute("aria-selected", "true")
+
+    await user.keyboard("{Enter}")
+    expect(screen.getByPlaceholderText("Ingrese el expediente")).toHaveValue("ABC-456")
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+  })
+
+  it("cierra el desplegable con Escape", async () => {
+    const user = userEvent.setup()
+    render(<Component />)
+
+    await typeInSearch(user, "ABC")
+    await screen.findByRole("listbox")
+
+    await user.keyboard("{Escape}")
+    await waitFor(() => expect(screen.queryByRole("listbox")).not.toBeInTheDocument())
+  })
+
+  it("deshabilita el slider de opacidad mientras la capa está apagada", async () => {
+    render(<Component />)
+
+    expect(screen.getByLabelText("Opacidad de Títulos Vigentes")).toBeDisabled()
+    expect(screen.getByLabelText("Opacidad de Subcontratos")).toBeDisabled()
+  })
+})

--- a/app/hooks/map/useDrawControl.js
+++ b/app/hooks/map/useDrawControl.js
@@ -1,73 +1,48 @@
-import { useState, useEffect } from "react"
+import { useState, useEffect, useRef } from "react"
 import L from "leaflet"
+import { createDrawOptions, DEFAULT_DRAWING_COLOR } from "../../utils/drawOptions"
 
-export const useDrawControl = (mapRef, drawControlRef, drawnItemsRef) => {
-  const [drawingColor, setDrawingColor] = useState("#f357a1")
+export const useDrawControl = (mapRef, mapInstance, drawControlRef, drawnItemsRef, measureControlRef) => {
+  const [drawingColor, setDrawingColor] = useState(DEFAULT_DRAWING_COLOR)
   const [showColorPicker, setShowColorPicker] = useState(false)
+
+  // Las herramientas de medición se crean una sola vez, dentro del efecto de
+  // inicialización del mapa, y capturaban el color del primer render: cambiarlo en el
+  // selector no las afectaba. Con un ref siempre leen el valor actual.
+  const drawingColorRef = useRef(drawingColor)
+
+  useEffect(() => {
+    drawingColorRef.current = drawingColor
+  }, [drawingColor])
 
   const handleColorChange = (newColor) => {
     setDrawingColor(newColor)
   }
 
-  // Actualizar el control de dibujo cuando cambie el color
+  // Leaflet.Draw copia las shapeOptions al construir cada manejador, así que cambiar
+  // el color obliga a recrear el control.
   useEffect(() => {
-    if (mapRef.current && drawControlRef.current) {
-      // Remover el control actual
-      mapRef.current.removeControl(drawControlRef.current)
+    if (!mapInstance || !drawnItemsRef.current) return
 
-      // Crear un nuevo control con el color actualizado
-      drawControlRef.current = new L.Control.Draw({
-        position: "topright",
-        draw: {
-          polyline: {
-            shapeOptions: {
-              color: drawingColor,
-              weight: 5,
-            },
-          },
-          polygon: {
-            allowIntersection: false,
-            drawError: {
-              color: "#e1e100",
-              message: "<strong>¡Error!</strong> No se permiten polígonos que se intersecten.",
-            },
-            shapeOptions: {
-              color: drawingColor,
-            },
-          },
-          circle: {
-            shapeOptions: {
-              color: drawingColor,
-            },
-          },
-          rectangle: {
-            shapeOptions: {
-              color: drawingColor,
-            },
-          },
-          marker: {
-            icon: new L.Icon({
-              iconUrl: "https://unpkg.com/leaflet@1.7.1/dist/images/marker-icon.png",
-              iconRetinaUrl: "https://unpkg.com/leaflet@1.7.1/dist/images/marker-icon-2x.png",
-              shadowUrl: "https://unpkg.com/leaflet@1.7.1/dist/images/marker-shadow.png",
-              iconSize: [25, 41],
-              iconAnchor: [12, 41],
-              popupAnchor: [1, -34],
-              shadowSize: [41, 41],
-            }),
-          },
-          circlemarker: false,
-        },
-        edit: {
-          featureGroup: drawnItemsRef.current,
-          remove: true,
-        },
-      })
+    const map = mapInstance
 
-      // Añadir el nuevo control al mapa
-      mapRef.current.addControl(drawControlRef.current)
+    if (drawControlRef.current) {
+      map.removeControl(drawControlRef.current)
     }
-  }, [drawingColor, mapRef, drawControlRef, drawnItemsRef])
+    // Los controles se apilan en el orden en que se añaden. Recreando solo el de
+    // dibujo, este saltaba por debajo del de medición cada vez que se cambiaba el
+    // color; re-añadir el de medición después conserva el orden de la barra.
+    if (measureControlRef?.current) {
+      map.removeControl(measureControlRef.current)
+    }
+
+    drawControlRef.current = new L.Control.Draw(createDrawOptions(drawingColor, drawnItemsRef.current))
+    map.addControl(drawControlRef.current)
+
+    if (measureControlRef?.current) {
+      map.addControl(measureControlRef.current)
+    }
+  }, [drawingColor, mapInstance, drawControlRef, drawnItemsRef, measureControlRef])
 
   // Cerrar el selector de colores cuando se hace clic fuera de él
   useEffect(() => {
@@ -94,5 +69,5 @@ export const useDrawControl = (mapRef, drawControlRef, drawnItemsRef) => {
     }
   }, [showColorPicker])
 
-  return { drawingColor, handleColorChange, showColorPicker, setShowColorPicker }
+  return { drawingColor, drawingColorRef, handleColorChange, showColorPicker, setShowColorPicker }
 }

--- a/app/hooks/map/useExpedientSearch.js
+++ b/app/hooks/map/useExpedientSearch.js
@@ -3,6 +3,12 @@ import L from "leaflet"
 import { createPopupContent, extractRings } from "../../utils/mapUtils"
 import { createLabelMarker } from "../../utils/mapLabels"
 import { fetchArcgisJson } from "../../utils/arcgis"
+import {
+  findTenureLayerNumbers,
+  REQUEST_LAYER_NAME,
+  TITLE_LAYER_NAME,
+  tenureLayerUrl,
+} from "../../utils/tenureLayers"
 
 export const useExpedientSearch = (
   mapRef,
@@ -10,7 +16,6 @@ export const useExpedientSearch = (
   expedientCode,
   searchTrigger,
   onCoordinatesUpdate,
-  findLayerNumbers,
   setError,
   setShowErrorBanner,
   geoJsonLayerRef,
@@ -36,27 +41,31 @@ export const useExpedientSearch = (
     const searchId = searchIdRef.current
     const isStale = () => searchId !== searchIdRef.current
 
-    const layerNumbers = await findLayerNumbers()
+    const layerNumbers = await findTenureLayerNumbers()
     if (isStale()) return
 
-    const layers = [
-      {
-        url: `https://annamineria.anm.gov.co/annageo/rest/services/SIGM/TenureLayers/MapServer/${layerNumbers["Título Vigente"]}/query`,
-        style: { color: "#894444", weight: 3, fillColor: "#A46F48", fillOpacity: 0.6 },
-      },
+    // Una capa que no se pudo descubrir se omite en vez de construir una URL con
+    // ".../MapServer/undefined/query", pero sigue contando en el total para que el
+    // mensaje de error no mienta sobre cuántas capas se consultaron de verdad.
+    const dynamicLayer = (layerName, style) => {
+      const layerNumber = layerNumbers[layerName]
+      return layerNumber === undefined ? null : { url: `${tenureLayerUrl(layerNumber)}/query`, style }
+    }
+
+    const allLayers = [
+      dynamicLayer(TITLE_LAYER_NAME, { color: "#894444", weight: 3, fillColor: "#A46F48", fillOpacity: 0.6 }),
       {
         url: "https://geo.anm.gov.co/webgis/rest/services/ANM/ServiciosANM/MapServer/3/query",
         style: { color: "#6E4B3A", weight: 3, fillColor: "#B68863", fillOpacity: 0.6 },
       },
-      {
-        url: `https://annamineria.anm.gov.co/annageo/rest/services/SIGM/TenureLayers/MapServer/${layerNumbers["Solicitud Vigente"]}/query`,
-        style: { color: "#F0C567", weight: 3, fillColor: "#FFF0AF", fillOpacity: 0.6 },
-      },
+      dynamicLayer(REQUEST_LAYER_NAME, { color: "#F0C567", weight: 3, fillColor: "#FFF0AF", fillOpacity: 0.6 }),
       {
         url: "https://annamineria.anm.gov.co/annageo/rest/services/SIGM/VisorInterno/MapServer/87/query",
         style: { color: "#22577A", weight: 3, fillColor: "#38A3A5", fillOpacity: 0.6 },
       },
     ]
+    const layers = allLayers.filter(Boolean)
+    const totalLayers = allLayers.length
 
     // Los vértices también: antes una búsqueda fallida dejaba en el mapa los
     // círculos rojos del expediente anterior.
@@ -74,7 +83,7 @@ export const useExpedientSearch = (
     // tiene el expediente. Solo cuenta como caída si fallan las dos: cada capa se
     // sondea con TENURE_ID y con CODIGO_EXPEDIENTE, y es normal que una de ellas
     // devuelva un error de campo inexistente.
-    let unreachableLayers = 0
+    let unreachableLayers = totalLayers - layers.length
 
     for (const layer of layers) {
       const queries = [
@@ -150,16 +159,16 @@ export const useExpedientSearch = (
     if (isStale()) return
 
     setShowErrorBanner(true)
-    if (unreachableLayers === layers.length) {
+    if (unreachableLayers === totalLayers) {
       setError("No se pudo consultar ninguna de las capas de la ANM. Revisa tu conexión e inténtalo de nuevo.")
     } else if (unreachableLayers > 0) {
-      setError(`${unreachableLayers} de ${layers.length} capas de la ANM no respondieron, y el expediente '${expedientCode}' no se encontró en las demás.`)
+      setError(`${unreachableLayers} de ${totalLayers} capas de la ANM no respondieron, y el expediente '${expedientCode}' no se encontró en las demás.`)
     } else {
       setError(`No se encontró un polígono con el expediente introducido '${expedientCode}'.`)
     }
     onCoordinatesUpdate([], null)
   }, [
-    expedientCode, onCoordinatesUpdate, findLayerNumbers, mapInstance,
+    expedientCode, onCoordinatesUpdate, mapInstance,
     setError, setShowErrorBanner, geoJsonLayerRef, labelsLayerRef, verticesLayerRef
   ])
 

--- a/app/hooks/map/useExpedientSearch.js
+++ b/app/hooks/map/useExpedientSearch.js
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useCallback } from "react"
 import L from "leaflet"
-import { getLabelCoordinates, getFeatureLabel, createPopupContent, extractRings } from "../../utils/mapUtils"
+import { createPopupContent, extractRings } from "../../utils/mapUtils"
+import { createLabelMarker } from "../../utils/mapLabels"
 import { fetchArcgisJson } from "../../utils/arcgis"
 
 export const useExpedientSearch = (
@@ -102,36 +103,27 @@ export const useExpedientSearch = (
             geoJsonLayerRef.current = L.geoJSON(data, {
               style: layer.style,
               onEachFeature: (feature, layer) => {
-                const bestPoint = getLabelCoordinates(feature)
+                const marker = createLabelMarker(feature)
 
-                if (bestPoint) {
-                  const [long, lat] = bestPoint
-
-                  const label = L.divIcon({
-                    className: "map-label",
-                    html: `<div>${getFeatureLabel(feature.properties)}</div>`,
-                    iconSize: [100, 40],
-                    iconAnchor: [50, 20],
-                  })
-
+                if (marker) {
                   if (!labelsLayerRef.current) {
                     labelsLayerRef.current = L.layerGroup()
                   }
-                  const marker = L.marker([lat, long], { icon: label })
                   labelsLayerRef.current.addLayer(marker)
                 }
 
-                const popupContent = createPopupContent(feature.properties)
-                layer.bindPopup(popupContent)
+                layer.bindPopup(createPopupContent(feature.properties))
               },
             }).addTo(mapRef.current)
 
-            const currentZoom = mapRef.current.getZoom()
-            if (currentZoom >= 15 && currentZoom <= 19 && labelsLayerRef.current) {
+            mapRef.current.fitBounds(geoJsonLayerRef.current.getBounds())
+
+            // La etiqueta del expediente buscado se muestra siempre: es un único
+            // resultado que el usuario pidió explícitamente, y fitBounds suele dejar
+            // el mapa por debajo del zoom mínimo de las capas masivas.
+            if (labelsLayerRef.current) {
               mapRef.current.addLayer(labelsLayerRef.current)
             }
-
-            mapRef.current.fitBounds(geoJsonLayerRef.current.getBounds())
 
             // Todas las features y todos sus anillos, no solo la primera.
             const rings = extractRings(data)

--- a/app/hooks/map/useExpedientSearch.test.js
+++ b/app/hooks/map/useExpedientSearch.test.js
@@ -1,6 +1,11 @@
 import { renderHook, waitFor } from "@testing-library/react"
 import { useExpedientSearch } from "./useExpedientSearch"
 
+jest.mock("../../utils/tenureLayers", () => ({
+  ...jest.requireActual("../../utils/tenureLayers"),
+  findTenureLayerNumbers: async () => ({ "Título Vigente": 3, "Solicitud Vigente": 4 }),
+}))
+
 // Leaflet no funciona en jsdom, así que sustituimos las fábricas que usa el hook por
 // dobles que registran qué se añadió al mapa.
 jest.mock("leaflet", () => {
@@ -75,7 +80,6 @@ const renderSearch = (map, overrides = {}) => {
         "ABC-123",
         searchTrigger,
         props.onCoordinatesUpdate,
-        async () => ({ "Título Vigente": 3, "Solicitud Vigente": 4 }),
         props.setError,
         props.setShowErrorBanner,
         refs.geoJson,

--- a/app/hooks/map/useMapLayers.js
+++ b/app/hooks/map/useMapLayers.js
@@ -79,9 +79,14 @@ export const useMapLayers = (
     const isStale = () => runId !== updateRunIdRef.current
 
     const updateLayer = async (show, layerRef, labelsLayerRef, layerName, layerStyle, customUrl = null) => {
+      // Capa apagada y todavía sin crear: no hay nada que hacer. Resolver la URL aquí
+      // disparaba el descubrimiento de capas nada más cargar la página, con los cuatro
+      // interruptores en off, y sacaba el banner de error si el servicio no respondía.
+      if (!show && !layerRef.current) return
+
       let layerUrl = customUrl
 
-      if (!layerUrl) {
+      if (show && !layerUrl) {
         const layerNumbers = await findTenureLayerNumbers()
         if (isStale()) return
 

--- a/app/hooks/map/useMapLayers.js
+++ b/app/hooks/map/useMapLayers.js
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useCallback, useState } from "react"
 import L from "leaflet"
 import * as EsriLeaflet from "esri-leaflet"
-import { getLabelCoordinates, getFeatureLabel, createPopupContent } from "../../utils/mapUtils"
+import { createPopupContent } from "../../utils/mapUtils"
+import { createLabelMarker, shouldShowLabels, syncLabelsWithFeatures } from "../../utils/mapLabels"
 import { fetchArcgisJson } from "../../utils/arcgis"
 
 const TENURE_LAYERS_URL = "https://annamineria.anm.gov.co/annageo/rest/services/SIGM/TenureLayers/MapServer"
@@ -61,13 +62,11 @@ export const useMapLayers = (
     historicalTitleOpacityRef.current = historicalTitleOpacity
   }, [historicalTitleOpacity])
 
-  const shouldShowTitleLayer = showTitleLayer && titleOpacity > 0
-  const shouldShowRequestLayer = showRequestLayer && requestOpacity > 0
-  const shouldShowAnmServiceLayer = showAnmServiceLayer && anmServiceOpacity > 0
-  const shouldShowHistoricalTitleLayer = showHistoricalTitleLayer && historicalTitleOpacity > 0
-
+  // El interruptor decide si la capa existe; el slider solo controla el relleno.
+  // Antes una opacidad de 0 destruía la capa entera —contorno incluido— y forzaba a
+  // recargarla desde el servidor al volver a subir el slider.
   const anyLayerEnabled =
-    shouldShowTitleLayer || shouldShowRequestLayer || shouldShowAnmServiceLayer || shouldShowHistoricalTitleLayer
+    showTitleLayer || showRequestLayer || showAnmServiceLayer || showHistoricalTitleLayer
 
   const findLayerNumbers = useCallback(async () => {
     if (layerNumbersCacheRef.current) {
@@ -145,37 +144,33 @@ export const useMapLayers = (
 
       if (show) {
         if (!layerRef.current) {
+          // Poblado desde onEachFeature; syncLabelsWithFeatures lo usa para quitar y
+          // reponer las etiquetas según entran y salen del viewport.
+          const labelMarkers = new Map()
+
           layerRef.current = EsriLeaflet.featureLayer({
             url: layerUrl,
             style: layerStyle,
             minZoom: LAYERS_MIN_ZOOM,
             onEachFeature: (feature, layer) => {
-              const bestPoint = getLabelCoordinates(feature)
+              const marker = createLabelMarker(feature)
 
-              if (bestPoint) {
-                const [long, lat] = bestPoint
-
-                const label = L.divIcon({
-                  className: "map-label",
-                  html: `<div>${getFeatureLabel(feature.properties)}</div>`,
-                  iconSize: [100, 40],
-                  iconAnchor: [50, 20],
-                })
-
+              if (marker) {
                 if (!labelsLayerRef.current) {
                   labelsLayerRef.current = L.layerGroup()
                 }
-                const marker = L.marker([lat, long], { icon: label })
                 labelsLayerRef.current.addLayer(marker)
+                labelMarkers.set(feature.id, marker)
               }
 
-              const popupContent = createPopupContent(feature.properties)
-              layer.bindPopup(popupContent)
+              layer.bindPopup(createPopupContent(feature.properties))
             },
-          }).addTo(mapRef.current)
+          })
 
-          const currentZoom = mapRef.current.getZoom()
-          if (currentZoom >= 15 && currentZoom <= 19 && labelsLayerRef.current) {
+          syncLabelsWithFeatures(layerRef.current, labelsLayerRef, labelMarkers)
+          layerRef.current.addTo(mapRef.current)
+
+          if (shouldShowLabels(mapRef.current.getZoom()) && labelsLayerRef.current) {
             mapRef.current.addLayer(labelsLayerRef.current)
           }
         } else {
@@ -206,14 +201,14 @@ export const useMapLayers = (
       try {
         await Promise.all([
           updateLayer(
-            shouldShowTitleLayer,
+            showTitleLayer,
             titleLayerRef,
             titleLabelsLayerRef,
             "Título Vigente",
             { color: "#894444", weight: 2, fillColor: "#A46F48", fillOpacity: titleOpacity },
           ),
           updateLayer(
-            shouldShowAnmServiceLayer,
+            showAnmServiceLayer,
             anmServiceLayerRef,
             anmServiceLabelsLayerRef,
             null,
@@ -221,14 +216,14 @@ export const useMapLayers = (
             "https://geo.anm.gov.co/webgis/rest/services/ANM/ServiciosANM/MapServer/3",
           ),
           updateLayer(
-            shouldShowRequestLayer,
+            showRequestLayer,
             requestLayerRef,
             requestLabelsLayerRef,
             "Solicitud Vigente",
             { color: "#F0C567", weight: 2, fillColor: "#FFF0AF", fillOpacity: requestOpacity },
           ),
           updateLayer(
-            shouldShowHistoricalTitleLayer,
+            showHistoricalTitleLayer,
             historicalTitleLayerRef,
             historicalTitleLabelsLayerRef,
             null,
@@ -250,10 +245,10 @@ export const useMapLayers = (
     run()
   }, [
     mapInstance,
-    shouldShowTitleLayer,
-    shouldShowRequestLayer,
-    shouldShowAnmServiceLayer,
-    shouldShowHistoricalTitleLayer,
+    showTitleLayer,
+    showRequestLayer,
+    showAnmServiceLayer,
+    showHistoricalTitleLayer,
     titleOpacity,
     requestOpacity,
     anmServiceOpacity,

--- a/app/hooks/map/useMapLayers.js
+++ b/app/hooks/map/useMapLayers.js
@@ -3,11 +3,12 @@ import L from "leaflet"
 import * as EsriLeaflet from "esri-leaflet"
 import { createPopupContent } from "../../utils/mapUtils"
 import { createLabelMarker, shouldShowLabels, syncLabelsWithFeatures } from "../../utils/mapLabels"
-import { fetchArcgisJson } from "../../utils/arcgis"
-
-const TENURE_LAYERS_URL = "https://annamineria.anm.gov.co/annageo/rest/services/SIGM/TenureLayers/MapServer"
-const REQUIRED_LAYER_NAMES = ["Solicitud Vigente", "Título Vigente"]
-const LAYER_PROBE_RANGE = [0, 1, 2, 3, 4, 5]
+import {
+  findTenureLayerNumbers,
+  REQUEST_LAYER_NAME,
+  TITLE_LAYER_NAME,
+  tenureLayerUrl,
+} from "../../utils/tenureLayers"
 
 // Estas capas cubren todo el país. Pedirlas a zoom bajo trae decenas de miles de
 // polígonos: ArcGIS corta la respuesta en maxRecordCount y el mapa quedaba mostrando
@@ -40,8 +41,6 @@ export const useMapLayers = (
   const requestOpacityRef = useRef(requestOpacity)
   const anmServiceOpacityRef = useRef(anmServiceOpacity)
   const historicalTitleOpacityRef = useRef(historicalTitleOpacity)
-  const layerNumbersCacheRef = useRef(null)
-  const layerNumbersPromiseRef = useRef(null)
   const updateRunIdRef = useRef(0)
 
   const [isBelowLayersMinZoom, setIsBelowLayersMinZoom] = useState(false)
@@ -68,57 +67,10 @@ export const useMapLayers = (
   const anyLayerEnabled =
     showTitleLayer || showRequestLayer || showAnmServiceLayer || showHistoricalTitleLayer
 
-  const findLayerNumbers = useCallback(async () => {
-    if (layerNumbersCacheRef.current) {
-      return layerNumbersCacheRef.current
-    }
-    // Compartir la consulta en vuelo: varias llamadas concurrentes repetían las seis
-    // peticiones de metadatos cada una.
-    if (layerNumbersPromiseRef.current) {
-      return layerNumbersPromiseRef.current
-    }
-
-    const request = (async () => {
-      const probes = await Promise.all(
-        LAYER_PROBE_RANGE.map(async (index) => {
-          try {
-            const data = await fetchArcgisJson(`${TENURE_LAYERS_URL}/${index}?f=json`)
-            return [data.name, index]
-          } catch (error) {
-            console.error(`Error checking layer ${index}:`, error)
-            return null
-          }
-        }),
-      )
-
-      const foundLayers = {}
-      probes.forEach((probe) => {
-        if (probe && REQUIRED_LAYER_NAMES.includes(probe[0])) {
-          foundLayers[probe[0]] = probe[1]
-        }
-      })
-
-      // No cachear un resultado incompleto: si todas las peticiones fallaban se
-      // guardaba {} para siempre y las capas dinámicas quedaban rotas hasta recargar.
-      if (REQUIRED_LAYER_NAMES.every((name) => foundLayers[name] !== undefined)) {
-        layerNumbersCacheRef.current = foundLayers
-      }
-
-      return foundLayers
-    })()
-
-    layerNumbersPromiseRef.current = request
-    try {
-      return await request
-    } finally {
-      layerNumbersPromiseRef.current = null
-    }
-  }, [])
-
   useEffect(() => {
     if (!mapInstance) return
 
-    // Cada ejecución invalida a la anterior. updateLayer espera a findLayerNumbers
+    // Cada ejecución invalida a la anterior. updateLayer espera a findTenureLayerNumbers
     // antes de mirar layerRef.current, así que dos ejecuciones solapadas (arrastrar
     // el slider de opacidad, alternar switches rápido) veían ambas el ref vacío y
     // creaban y añadían dos capas superpuestas.
@@ -130,14 +82,14 @@ export const useMapLayers = (
       let layerUrl = customUrl
 
       if (!layerUrl) {
-        const layerNumbers = await findLayerNumbers()
+        const layerNumbers = await findTenureLayerNumbers()
         if (isStale()) return
 
         const layerNumber = layerNumbers[layerName]
         if (layerNumber === undefined) {
           throw new Error(`No se encontró la capa "${layerName}" en el servicio de la ANM`)
         }
-        layerUrl = `${TENURE_LAYERS_URL}/${layerNumber}`
+        layerUrl = tenureLayerUrl(layerNumber)
       }
 
       if (isStale() || !mapRef.current) return
@@ -204,7 +156,7 @@ export const useMapLayers = (
             showTitleLayer,
             titleLayerRef,
             titleLabelsLayerRef,
-            "Título Vigente",
+            TITLE_LAYER_NAME,
             { color: "#894444", weight: 2, fillColor: "#A46F48", fillOpacity: titleOpacity },
           ),
           updateLayer(
@@ -219,7 +171,7 @@ export const useMapLayers = (
             showRequestLayer,
             requestLayerRef,
             requestLabelsLayerRef,
-            "Solicitud Vigente",
+            REQUEST_LAYER_NAME,
             { color: "#F0C567", weight: 2, fillColor: "#FFF0AF", fillOpacity: requestOpacity },
           ),
           updateLayer(
@@ -253,7 +205,6 @@ export const useMapLayers = (
     requestOpacity,
     anmServiceOpacity,
     historicalTitleOpacity,
-    findLayerNumbers,
     mapRef,
     setError,
     setShowErrorBanner
@@ -325,7 +276,6 @@ export const useMapLayers = (
   }, [mapInstance])
 
   return {
-    findLayerNumbers,
     // Una capa encendida por debajo del zoom mínimo no dibuja nada: hay que decirlo,
     // en vez de dejar el mapa vacío sin explicación.
     showZoomInHint: anyLayerEnabled && isBelowLayersMinZoom,

--- a/app/utils/drawOptions.js
+++ b/app/utils/drawOptions.js
@@ -1,0 +1,45 @@
+import L from "leaflet"
+
+export const DEFAULT_DRAWING_COLOR = "#f357a1"
+
+const MARKER_ICON_BASE = "https://unpkg.com/leaflet@1.7.1/dist/images"
+
+export const createMarkerIcon = () =>
+  new L.Icon({
+    iconUrl: `${MARKER_ICON_BASE}/marker-icon.png`,
+    iconRetinaUrl: `${MARKER_ICON_BASE}/marker-icon-2x.png`,
+    shadowUrl: `${MARKER_ICON_BASE}/marker-shadow.png`,
+    iconSize: [25, 41],
+    iconAnchor: [12, 41],
+    popupAnchor: [1, -34],
+    shadowSize: [41, 41],
+  })
+
+/**
+ * Opciones del control de dibujo. Estaban duplicadas casi literalmente entre
+ * MapComponent y useDrawControl, y las dos copias se desincronizaban.
+ */
+export const createDrawOptions = (color, featureGroup) => ({
+  position: "topright",
+  draw: {
+    polyline: {
+      shapeOptions: { color, weight: 5 },
+    },
+    polygon: {
+      allowIntersection: false,
+      drawError: {
+        color: "#e1e100",
+        message: "<strong>¡Error!</strong> No se permiten polígonos que se intersecten.",
+      },
+      shapeOptions: { color },
+    },
+    circle: { shapeOptions: { color } },
+    rectangle: { shapeOptions: { color } },
+    marker: { icon: createMarkerIcon() },
+    circlemarker: false,
+  },
+  edit: {
+    featureGroup,
+    remove: true,
+  },
+})

--- a/app/utils/exportUtils.js
+++ b/app/utils/exportUtils.js
@@ -1,14 +1,6 @@
-import { getFeatureLabel } from "./mapUtils"
+import { escapeXml, getFeatureLabel } from "./mapUtils"
 
-const XML_ENTITIES = {
-  "&": "&amp;",
-  "<": "&lt;",
-  ">": "&gt;",
-  '"': "&quot;",
-  "'": "&apos;",
-}
-
-export const escapeXml = (value) => String(value ?? "").replace(/[&<>"']/g, (char) => XML_ENTITIES[char])
+export { escapeXml }
 
 /** KML usa lon,lat,alt separados por espacios, y espera el anillo cerrado. */
 const ringToKml = (ring) => {

--- a/app/utils/mapLabels.js
+++ b/app/utils/mapLabels.js
@@ -1,0 +1,64 @@
+import L from "leaflet"
+import { escapeXml, getFeatureLabel, getLabelCoordinates } from "./mapUtils"
+
+// Por debajo de este zoom las etiquetas se apiñan y son ilegibles. No hay límite
+// superior: el satélite llega a z22 y antes desaparecían al pasar de z19.
+export const LABELS_MIN_ZOOM = 15
+
+export const shouldShowLabels = (zoom) => zoom >= LABELS_MIN_ZOOM
+
+/**
+ * Marcador con el código del expediente, anclado en un punto interior del polígono.
+ * @returns {Object|null} marcador de Leaflet, o null si la geometría no lo permite
+ */
+export const createLabelMarker = (feature) => {
+  const point = getLabelCoordinates(feature)
+  if (!point) {
+    return null
+  }
+
+  const [long, lat] = point
+
+  return L.marker([lat, long], {
+    icon: L.divIcon({
+      className: "map-label",
+      html: `<div>${escapeXml(getFeatureLabel(feature.properties))}</div>`,
+      iconSize: [100, 40],
+      iconAnchor: [50, 20],
+    }),
+  })
+}
+
+/**
+ * Mantiene el grupo de etiquetas sincronizado con las features visibles de una capa
+ * de esri-leaflet.
+ *
+ * esri-leaflet quita del mapa los polígonos que salen del viewport y los vuelve a
+ * poner al regresar, pero las etiquetas viven en un grupo aparte que nadie tocaba:
+ * se acumulaban indefinidamente al navegar y quedaban flotando sobre polígonos que
+ * ya no se dibujaban.
+ *
+ * @param {Object} featureLayer - capa de esri-leaflet
+ * @param {Object} labelsLayerRef - ref al L.layerGroup de etiquetas
+ * @param {Map} markers - marcadores indexados por id de feature, poblado desde onEachFeature
+ */
+export const syncLabelsWithFeatures = (featureLayer, labelsLayerRef, markers) => {
+  featureLayer.on("removefeature", (event) => {
+    const marker = markers.get(event.feature?.id)
+    if (!marker) {
+      return
+    }
+    labelsLayerRef.current?.removeLayer(marker)
+    // `permanent` significa que esri-leaflet descartó la feature de su caché.
+    if (event.permanent) {
+      markers.delete(event.feature.id)
+    }
+  })
+
+  featureLayer.on("addfeature", (event) => {
+    const marker = markers.get(event.feature?.id)
+    if (marker) {
+      labelsLayerRef.current?.addLayer(marker)
+    }
+  })
+}

--- a/app/utils/mapLabels.test.js
+++ b/app/utils/mapLabels.test.js
@@ -1,0 +1,126 @@
+import { createLabelMarker, shouldShowLabels, syncLabelsWithFeatures } from "./mapLabels"
+
+const SQUARE = [
+  [
+    [-75.6, 6.2],
+    [-75.57, 6.2],
+    [-75.57, 6.23],
+    [-75.6, 6.23],
+    [-75.6, 6.2],
+  ],
+]
+
+const feature = (properties, id = 1) => ({
+  id,
+  type: "Feature",
+  properties,
+  geometry: { type: "Polygon", coordinates: SQUARE },
+})
+
+describe("shouldShowLabels", () => {
+  it("oculta las etiquetas por debajo del zoom mínimo", () => {
+    expect(shouldShowLabels(14)).toBe(false)
+    expect(shouldShowLabels(15)).toBe(true)
+  })
+
+  it("las mantiene visibles por encima de z19", () => {
+    // Regresión: el rango era 15..19, así que en satélite (z22) desaparecían al
+    // acercarse más de la cuenta.
+    expect(shouldShowLabels(20)).toBe(true)
+    expect(shouldShowLabels(22)).toBe(true)
+  })
+})
+
+describe("createLabelMarker", () => {
+  it("crea el marcador con el código del expediente", () => {
+    const marker = createLabelMarker(feature({ TENURE_ID: "ABC-123" }))
+
+    expect(marker).not.toBeNull()
+    expect(marker.options.icon.options.html).toContain("ABC-123")
+  })
+
+  it("escapa el HTML del código", () => {
+    const marker = createLabelMarker(feature({ TENURE_ID: '<img src=x onerror=alert(1)>' }))
+
+    expect(marker.options.icon.options.html).not.toContain("<img")
+    expect(marker.options.icon.options.html).toContain("&lt;img")
+  })
+
+  it("devuelve null cuando la geometría no permite ubicar la etiqueta", () => {
+    expect(createLabelMarker({ id: 1, properties: {}, geometry: null })).toBeNull()
+  })
+})
+
+describe("syncLabelsWithFeatures", () => {
+  const createFeatureLayer = () => {
+    const handlers = {}
+    return {
+      on: (event, handler) => {
+        handlers[event] = handler
+      },
+      fire: (event, payload) => handlers[event]?.(payload),
+    }
+  }
+
+  const createLabelsGroup = () => {
+    const layers = new Set()
+    return {
+      current: {
+        addLayer: (l) => layers.add(l),
+        removeLayer: (l) => layers.delete(l),
+        size: () => layers.size,
+      },
+    }
+  }
+
+  it("quita la etiqueta cuando su polígono sale del viewport", () => {
+    // Regresión: esri-leaflet retira los polígonos fuera de vista, pero las etiquetas
+    // vivían en un grupo aparte y se acumulaban indefinidamente al navegar.
+    const featureLayer = createFeatureLayer()
+    const labelsLayerRef = createLabelsGroup()
+    const markers = new Map()
+
+    syncLabelsWithFeatures(featureLayer, labelsLayerRef, markers)
+
+    const marker = { id: "marcador" }
+    markers.set(7, marker)
+    labelsLayerRef.current.addLayer(marker)
+    expect(labelsLayerRef.current.size()).toBe(1)
+
+    featureLayer.fire("removefeature", { feature: { id: 7 }, permanent: false })
+    expect(labelsLayerRef.current.size()).toBe(0)
+    expect(markers.has(7)).toBe(true)
+  })
+
+  it("repone la etiqueta cuando el polígono vuelve a entrar", () => {
+    const featureLayer = createFeatureLayer()
+    const labelsLayerRef = createLabelsGroup()
+    const markers = new Map([[7, { id: "marcador" }]])
+
+    syncLabelsWithFeatures(featureLayer, labelsLayerRef, markers)
+
+    featureLayer.fire("addfeature", { feature: { id: 7 } })
+    expect(labelsLayerRef.current.size()).toBe(1)
+  })
+
+  it("olvida el marcador cuando esri-leaflet descarta la feature", () => {
+    const featureLayer = createFeatureLayer()
+    const labelsLayerRef = createLabelsGroup()
+    const markers = new Map([[7, { id: "marcador" }]])
+
+    syncLabelsWithFeatures(featureLayer, labelsLayerRef, markers)
+
+    featureLayer.fire("removefeature", { feature: { id: 7 }, permanent: true })
+    expect(markers.has(7)).toBe(false)
+  })
+
+  it("tolera eventos de features sin etiqueta", () => {
+    const featureLayer = createFeatureLayer()
+    const labelsLayerRef = createLabelsGroup()
+
+    syncLabelsWithFeatures(featureLayer, labelsLayerRef, new Map())
+
+    expect(() => featureLayer.fire("removefeature", { feature: { id: 99 } })).not.toThrow()
+    expect(() => featureLayer.fire("addfeature", {})).not.toThrow()
+  })
+})

--- a/app/utils/mapUtils.js
+++ b/app/utils/mapUtils.js
@@ -225,25 +225,42 @@ export const getLabelCoordinates = (feature) => {
 export const getFeatureLabel = (properties) =>
   properties?.TENURE_ID || properties?.CODIGO_EXPEDIENTE || "N/A"
 
-export const createPopupContent = (properties) => {
+const MARKUP_ENTITIES = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&apos;",
+}
+
+/**
+ * Escapa los cinco caracteres reservados de XML/HTML. Los atributos de la ANM se
+ * interpolan en HTML (popups, etiquetas) y en XML (KML) sin ningún saneamiento.
+ */
+export const escapeXml = (value) => String(value ?? "").replace(/[&<>"']/g, (char) => MARKUP_ENTITIES[char])
+
+const field = (value) => escapeXml(value || "N/A")
+
+export const createPopupContent = (properties = {}) => {
+  const area =
+    typeof properties.AREA_HA === "number" ? properties.AREA_HA.toFixed(4) : properties.AREA_HA || "N/A"
+
   return `
     <div class="popup-content">
       <h3>Información del Expediente</h3>
-      <p><strong>Código Expediente:</strong> ${properties.CODIGO_EXPEDIENTE || properties.TENURE_ID || "N/A"}</p>
-      <p><strong>Modalidad:</strong> ${properties.MODALIDAD || "N/A"}</p>
-      <p><strong>Estado del Título:</strong> ${properties.TITULO_ESTADO || properties.STATUS || "N/A"}</p>
-      <p><strong>Área (ha):</strong> ${
-        typeof properties.AREA_HA === "number" ? properties.AREA_HA.toFixed(4) : properties.AREA_HA || "N/A"
-      }</p>
-      <p><strong>Clasificación Minería:</strong> ${properties.CLASIFICACION_MINERIA || "N/A"}</p>
-      <p><strong>Etapa:</strong> ${properties.ETAPA || "N/A"}</p>
-      <p><strong>Solicitantes o Titulares:</strong> ${properties.SOLICITANTES_O_TITULARES || "N/A"}</p>
-      <p><strong>Minerales:</strong> ${properties.MINERALES || "N/A"}</p>
-      <p><strong>Fecha de Solicitud:</strong> ${formatDate(properties.FECHA_DE_SOLICITUD)}</p>
-      <p><strong>Fecha de Expedición:</strong> ${formatDate(properties.FECHA_DE_EXPEDICION)}</p>
-      <p><strong>Fecha de Aniversario:</strong> ${formatDate(properties.FECHA_DE_ANIVERSARIO)}</p>
-      <p><strong>Fecha de Expiración:</strong> ${formatDate(properties.FECHA_DE_EXPIRACION)}</p>
-      <p><strong>PAR:</strong> ${properties.PAR || "N/A"}</p>
+      <p><strong>Código Expediente:</strong> ${field(properties.CODIGO_EXPEDIENTE || properties.TENURE_ID)}</p>
+      <p><strong>Modalidad:</strong> ${field(properties.MODALIDAD)}</p>
+      <p><strong>Estado del Título:</strong> ${field(properties.TITULO_ESTADO || properties.STATUS)}</p>
+      <p><strong>Área (ha):</strong> ${escapeXml(area)}</p>
+      <p><strong>Clasificación Minería:</strong> ${field(properties.CLASIFICACION_MINERIA)}</p>
+      <p><strong>Etapa:</strong> ${field(properties.ETAPA)}</p>
+      <p><strong>Solicitantes o Titulares:</strong> ${field(properties.SOLICITANTES_O_TITULARES)}</p>
+      <p><strong>Minerales:</strong> ${field(properties.MINERALES)}</p>
+      <p><strong>Fecha de Solicitud:</strong> ${escapeXml(formatDate(properties.FECHA_DE_SOLICITUD))}</p>
+      <p><strong>Fecha de Expedición:</strong> ${escapeXml(formatDate(properties.FECHA_DE_EXPEDICION))}</p>
+      <p><strong>Fecha de Aniversario:</strong> ${escapeXml(formatDate(properties.FECHA_DE_ANIVERSARIO))}</p>
+      <p><strong>Fecha de Expiración:</strong> ${escapeXml(formatDate(properties.FECHA_DE_EXPIRACION))}</p>
+      <p><strong>PAR:</strong> ${field(properties.PAR)}</p>
     </div>
   `
 }

--- a/app/utils/mapUtils.test.js
+++ b/app/utils/mapUtils.test.js
@@ -1,5 +1,5 @@
 import * as turf from "@turf/turf"
-import { extractRings, formatDegrees, getLabelCoordinates, getFeatureLabel } from "./mapUtils"
+import { createPopupContent, extractRings, formatDegrees, getLabelCoordinates, getFeatureLabel } from "./mapUtils"
 
 const polygonFeature = (coordinates) => ({
   type: "Feature",
@@ -207,5 +207,24 @@ describe("getFeatureLabel", () => {
   it("devuelve N/A sin lanzar cuando no hay propiedades", () => {
     expect(getFeatureLabel(undefined)).toBe("N/A")
     expect(getFeatureLabel({})).toBe("N/A")
+  })
+})
+
+describe("createPopupContent", () => {
+  it("escapa los atributos que vienen del servicio", () => {
+    // Los atributos se interpolan directamente en el HTML del popup.
+    const html = createPopupContent({
+      TENURE_ID: '<script>alert(1)</script>',
+      SOLICITANTES_O_TITULARES: 'Minas "El Roble" & Cía',
+    })
+
+    expect(html).not.toContain("<script>")
+    expect(html).toContain("&lt;script&gt;")
+    expect(html).toContain("Minas &quot;El Roble&quot; &amp; Cía")
+  })
+
+  it("no lanza sin propiedades", () => {
+    expect(() => createPopupContent()).not.toThrow()
+    expect(createPopupContent()).toContain("N/A")
   })
 })

--- a/app/utils/tenureLayers.js
+++ b/app/utils/tenureLayers.js
@@ -1,0 +1,76 @@
+import { fetchArcgisJson } from "./arcgis"
+
+export const TENURE_LAYERS_URL =
+  "https://annamineria.anm.gov.co/annageo/rest/services/SIGM/TenureLayers/MapServer"
+
+export const TITLE_LAYER_NAME = "Título Vigente"
+export const REQUEST_LAYER_NAME = "Solicitud Vigente"
+
+const REQUIRED_LAYER_NAMES = [REQUEST_LAYER_NAME, TITLE_LAYER_NAME]
+const LAYER_PROBE_RANGE = [0, 1, 2, 3, 4, 5]
+
+export const tenureLayerUrl = (layerNumber) => `${TENURE_LAYERS_URL}/${layerNumber}`
+
+let cachedLayerNumbers = null
+let inFlightRequest = null
+
+/**
+ * Descubre en qué índice publica la ANM cada capa. Los números cambian entre
+ * despliegues del servicio, así que no se pueden fijar en el código.
+ *
+ * La caché es de módulo para que el mapa, la búsqueda y el autocompletado usen los
+ * mismos números: antes el autocompletado los tenía fijos en 3 y 4 mientras el resto
+ * de la aplicación los descubría, y las dos vías podían discrepar.
+ */
+export const findTenureLayerNumbers = async () => {
+  if (cachedLayerNumbers) {
+    return cachedLayerNumbers
+  }
+  // Compartir la consulta en vuelo: varias llamadas concurrentes repetían las seis
+  // peticiones de metadatos cada una.
+  if (inFlightRequest) {
+    return inFlightRequest
+  }
+
+  const request = (async () => {
+    const probes = await Promise.all(
+      LAYER_PROBE_RANGE.map(async (index) => {
+        try {
+          const data = await fetchArcgisJson(`${TENURE_LAYERS_URL}/${index}?f=json`)
+          return [data.name, index]
+        } catch (error) {
+          console.error(`No se pudo leer la capa ${index}:`, error)
+          return null
+        }
+      }),
+    )
+
+    const foundLayers = {}
+    probes.forEach((probe) => {
+      if (probe && REQUIRED_LAYER_NAMES.includes(probe[0])) {
+        foundLayers[probe[0]] = probe[1]
+      }
+    })
+
+    // No cachear un resultado incompleto: si todas las peticiones fallaban se guardaba
+    // {} para siempre y las capas dinámicas quedaban rotas hasta recargar la página.
+    if (REQUIRED_LAYER_NAMES.every((name) => foundLayers[name] !== undefined)) {
+      cachedLayerNumbers = foundLayers
+    }
+
+    return foundLayers
+  })()
+
+  inFlightRequest = request
+  try {
+    return await request
+  } finally {
+    inFlightRequest = null
+  }
+}
+
+/** Solo para pruebas. */
+export const resetTenureLayerCache = () => {
+  cachedLayerNumbers = null
+  inFlightRequest = null
+}

--- a/app/utils/tenureLayers.test.js
+++ b/app/utils/tenureLayers.test.js
@@ -1,0 +1,82 @@
+import { findTenureLayerNumbers, resetTenureLayerCache, tenureLayerUrl } from "./tenureLayers"
+
+const layerMetadata = { 3: "Título Vigente", 4: "Solicitud Vigente" }
+
+const respondWithMetadata = () =>
+  jest.fn(async (url) => {
+    const index = Number(String(url).match(/MapServer\/(\d+)\?/)[1])
+    return { ok: true, json: async () => ({ name: layerMetadata[index] ?? `Otra capa ${index}` }) }
+  })
+
+describe("findTenureLayerNumbers", () => {
+  beforeEach(() => {
+    resetTenureLayerCache()
+    jest.spyOn(console, "error").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it("descubre el índice de cada capa", async () => {
+    global.fetch = respondWithMetadata()
+
+    await expect(findTenureLayerNumbers()).resolves.toEqual({
+      "Título Vigente": 3,
+      "Solicitud Vigente": 4,
+    })
+  })
+
+  it("reutiliza la caché en llamadas posteriores", async () => {
+    global.fetch = respondWithMetadata()
+
+    await findTenureLayerNumbers()
+    const callsAfterFirst = global.fetch.mock.calls.length
+    await findTenureLayerNumbers()
+
+    expect(global.fetch.mock.calls.length).toBe(callsAfterFirst)
+  })
+
+  it("comparte la consulta en vuelo entre llamadas concurrentes", async () => {
+    // Antes cada llamada concurrente repetía las seis peticiones de metadatos.
+    global.fetch = respondWithMetadata()
+
+    await Promise.all([findTenureLayerNumbers(), findTenureLayerNumbers(), findTenureLayerNumbers()])
+
+    expect(global.fetch).toHaveBeenCalledTimes(6)
+  })
+
+  it("no cachea un resultado incompleto", async () => {
+    // Regresión: si fallaban todas las peticiones se guardaba {} para siempre y las
+    // capas quedaban rotas hasta recargar la página.
+    global.fetch = jest.fn(async () => {
+      throw new Error("Network error")
+    })
+
+    await expect(findTenureLayerNumbers()).resolves.toEqual({})
+
+    global.fetch = respondWithMetadata()
+    await expect(findTenureLayerNumbers()).resolves.toEqual({
+      "Título Vigente": 3,
+      "Solicitud Vigente": 4,
+    })
+  })
+
+  it("tolera que una sola capa falle", async () => {
+    global.fetch = jest.fn(async (url) => {
+      const index = Number(String(url).match(/MapServer\/(\d+)\?/)[1])
+      if (index === 4) throw new Error("Network error")
+      return { ok: true, json: async () => ({ name: layerMetadata[index] ?? `Otra capa ${index}` }) }
+    })
+
+    await expect(findTenureLayerNumbers()).resolves.toEqual({ "Título Vigente": 3 })
+  })
+})
+
+describe("tenureLayerUrl", () => {
+  it("construye la URL de la capa", () => {
+    expect(tenureLayerUrl(3)).toBe(
+      "https://annamineria.anm.gov.co/annageo/rest/services/SIGM/TenureLayers/MapServer/3",
+    )
+  })
+})


### PR DESCRIPTION
Continuación de #66 y #67, que ya cubrieron la ubicación de etiquetas, las búsquedas concurrentes, la exportación y la carga de capas. Estos tres commits atacan el resto de los problemas de visualización y extracción detectados en la revisión.

## Etiquetas y escape de HTML (`24d613b`)

- **Las etiquetas se acumulaban sin límite al navegar.** esri-leaflet quita del mapa los polígonos que salen del viewport y los repone al volver, pero las etiquetas vivían en un `layerGroup` aparte que nadie tocaba: quedaban flotando sobre polígonos que ya no se dibujaban. `syncLabelsWithFeatures` escucha `addfeature`/`removefeature` y mantiene el grupo al día.
- **Las etiquetas desaparecían por encima de z19.** El rango era 15–19 y el satélite llega a z22, así que se ocultaban justo al acercarse. Se quita el límite superior.
- **La etiqueta del expediente buscado no se veía nunca.** `fitBounds` sobre un título típico deja el mapa en z≈13, por debajo del umbral. Al ser un único resultado pedido explícitamente, ahora se muestra siempre.
- **Los atributos de la ANM se interpolaban en el HTML de popups y etiquetas sin sanear.** Se escapan con `escapeXml`, que pasa a `mapUtils` para que lo compartan popup, etiqueta y KML.
- **El slider de opacidad en 0 destruía la capa entera**, contorno incluido, y forzaba a recargarla del servidor al volver a subirlo. Ahora el interruptor decide si la capa existe y el slider solo controla el relleno.

## Buscador de expedientes y descubrimiento de capas (`7319b12`)

- **El autocompletado tenía fijos los índices 3 y 4 de las capas de tenencia** mientras el mapa y la búsqueda los descubrían, así que las dos vías podían discrepar tras un despliegue de la ANM. El descubrimiento se traslada a `utils/tenureLayers`, con caché de módulo compartida por los tres.
- **Se consultaba en cada tecla, sin longitud mínima:** con una sola letra, `LIKE 'A%'` barre el dataset nacional. Ahora exige tres caracteres.
- **Sin cancelación,** una respuesta lenta podía llegar después de otra más reciente y pisar sus sugerencias. Se cancela con `AbortController`.
- **El desplegable se reabría 300 ms después de elegir una sugerencia,** porque la selección cambiaba `expedientCode` y eso volvía a disparar la consulta.
- **El desplegable se desbordaba:** era hermano del contenedor posicionado, así que su ancho se medía contra la barra lateral entera. Ahora vive dentro del contenedor del input, la detección de clic fuera apunta al contenedor y la selección usa `onMouseDown`, que se adelanta al cierre en lugar de competir con él.
- **URLs `.../MapServer/undefined/query`** cuando una capa no se podía descubrir. Se omite, pero sigue contando en el total para que el mensaje de error no mienta sobre cuántas capas se consultaron.
- **Accesibilidad:** `role` combobox/listbox/option, `aria-activedescendant` y navegación con flechas, Enter y Escape. El slider de Subcontratos era el único sin `aria-label`; los cuatro pasan por un `LayerControl` común que además los deshabilita cuando la capa está apagada. Corregido "Solicitudes Vigente".

## Herramientas de dibujo y medición (`26dd659`)

- **Las herramientas de medir siempre medían en rosa.** Se crean una sola vez dentro del efecto de inicialización y capturaban `drawingColor` del primer render, así que el selector de color nunca las afectaba. Leen el color desde un ref.
- **Cada clic en medir habilitaba un dibujante nuevo sin apagar el anterior,** dejando varios manejadores activos a la vez.
- **Cincuenta líneas de opciones de `L.Control.Draw` duplicadas** entre `MapComponent` y `useDrawControl`, que podían desincronizarse. Ahora salen de `createDrawOptions` y solo `useDrawControl` construye el control.
- **La barra de controles se desordenaba al cambiar el color.** Los controles de Leaflet se apilan en el orden en que se añaden, así que recrear solo el de dibujo lo hacía saltar por debajo del de medición.
- **Aparecía el banner rojo de error nada más cargar la página.** `updateLayer` resolvía la URL de la capa aunque el interruptor estuviera apagado, lo que disparaba el descubrimiento de capas sin que el usuario hubiera pedido ninguna. Regresión introducida en #67.
- **El panel colapsado dejaba asomar una franja de 16 px,** porque `-translate-x-full` solo desplaza el ancho del panel y este vive en `left-4`. Las etiquetas de las capas llevan ancho fijo para que las cuatro filas queden alineadas.

## Verificación

- `npx jest` → 69/69 en 8 suites. Se añaden `app/components.test.jsx`, `app/utils/mapLabels.test.js` y `app/utils/tenureLayers.test.js`.
- `npx next build` → correcto.
- Las pruebas de regresión de las etiquetas fuera del viewport y del desplegable que se reabre se comprobaron desactivando el arreglo: fallan sin él.
- Comprobado en Chromium: barra de controles en orden `zoom → dibujo → medición` antes y después de cambiar el color, sliders deshabilitados con la capa apagada, panel colapsado sin franja visible y ningún banner de error en la carga.

## Notas

- Rebasado sobre `main` tras el merge de #67; el hash del árbol es idéntico al de antes del rebase, así que el contenido no cambió.
- No relacionado con este diff, pero visto de paso: hay 33 archivos de `.next/cache` rastreados en git desde commits antiguos pese a que `.gitignore` incluye `.next`. Se limpian con `git rm -r --cached .next`.
- `npx tsc --noEmit` reporta tres errores de `toBeInTheDocument` en `ExportComponent.test.tsx` por los tipos de `jest-dom` ausentes en `tsconfig`. Son previos a esta rama y `next build` no los alcanza.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzwXzKx1PSKSBVx7Wfu3uQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzwXzKx1PSKSBVx7Wfu3uQ)_